### PR TITLE
feat: profession sounds

### DIFF
--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -306,6 +306,10 @@ public class LobotomizeStorage {
 
             if (this.restockSound != null) {
                 villager.getWorld().playSound(villager.getLocation(), this.restockSound, SoundCategory.NEUTRAL, 1.0F, 1.0F);
+            } else {
+                villager.getWorld().playSound(villager.getLocation(), VillagerUtils.PROFESSION_TO_SOUND.get(villager.getProfession()),
+                        SoundCategory.NEUTRAL, 1.0F,
+                        1.0F);
             }
         }
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
@@ -47,8 +47,8 @@ public class VillagerUtils {
         // Professions with no workstation
         map.put(Villager.Profession.NITWIT, null);
         map.put(Villager.Profession.NONE, null);
-        soundMap.put(Villager.Profession.NITWIT, null);
-        soundMap.put(Villager.Profession.NONE, null);
+        soundMap.put(Villager.Profession.NITWIT, Sound.ENTITY_VILLAGER_CELEBRATE);
+        soundMap.put(Villager.Profession.NONE, Sound.ENTITY_VILLAGER_CELEBRATE);
 
         // One time registered map
         PROFESSION_TO_SOUND = Collections.unmodifiableMap(soundMap);

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
@@ -1,6 +1,7 @@
 package dev.mja00.villagerLobotomizer.utils;
 
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Villager;
 
 import java.util.Collections;
@@ -9,9 +10,25 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class VillagerUtils {
     public static final Map<Villager.Profession, Material> PROFESSION_TO_STATION;
+    public static final Map<Villager.Profession, Sound> PROFESSION_TO_SOUND;
 
     static {
         Map<Villager.Profession, Material> map = new ConcurrentHashMap<>();
+        Map<Villager.Profession, Sound> soundMap = new ConcurrentHashMap<>();
+
+        soundMap.put(Villager.Profession.ARMORER, Sound.ENTITY_VILLAGER_WORK_ARMORER);
+        soundMap.put(Villager.Profession.BUTCHER, Sound.ENTITY_VILLAGER_WORK_BUTCHER);
+        soundMap.put(Villager.Profession.CARTOGRAPHER, Sound.ENTITY_VILLAGER_WORK_CARTOGRAPHER);
+        soundMap.put(Villager.Profession.CLERIC, Sound.ENTITY_VILLAGER_WORK_CLERIC);
+        soundMap.put(Villager.Profession.FARMER, Sound.ENTITY_VILLAGER_WORK_FARMER);
+        soundMap.put(Villager.Profession.FISHERMAN, Sound.ENTITY_VILLAGER_WORK_FISHERMAN);
+        soundMap.put(Villager.Profession.FLETCHER, Sound.ENTITY_VILLAGER_WORK_FLETCHER);
+        soundMap.put(Villager.Profession.LEATHERWORKER, Sound.ENTITY_VILLAGER_WORK_LEATHERWORKER);
+        soundMap.put(Villager.Profession.LIBRARIAN, Sound.ENTITY_VILLAGER_WORK_LIBRARIAN);
+        soundMap.put(Villager.Profession.MASON, Sound.ENTITY_VILLAGER_WORK_MASON);
+        soundMap.put(Villager.Profession.SHEPHERD, Sound.ENTITY_VILLAGER_WORK_SHEPHERD);
+        soundMap.put(Villager.Profession.TOOLSMITH, Sound.ENTITY_VILLAGER_WORK_TOOLSMITH);
+        soundMap.put(Villager.Profession.WEAPONSMITH, Sound.ENTITY_VILLAGER_WORK_WEAPONSMITH);
 
         map.put(Villager.Profession.ARMORER, Material.BLAST_FURNACE);
         map.put(Villager.Profession.BUTCHER, Material.SMOKER);
@@ -30,8 +47,11 @@ public class VillagerUtils {
         // Professions with no workstation
         map.put(Villager.Profession.NITWIT, null);
         map.put(Villager.Profession.NONE, null);
+        soundMap.put(Villager.Profession.NITWIT, null);
+        soundMap.put(Villager.Profession.NONE, null);
 
         // One time registered map
+        PROFESSION_TO_SOUND = Collections.unmodifiableMap(soundMap);
         PROFESSION_TO_STATION = Collections.unmodifiableMap(map);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,7 +16,7 @@ only-lobotomize-villagers-with-professions: false
 #Whether to lobotomize villagers in boats/minecarts. Does not apply to villagers riding on non-vehicle entities like horses.
 always-lobotomize-villagers-in-vehicles: false
 
-#The sound to play when a villager restocks. Leave empty ("") for no sound.
+#The sound to play when a villager restocks. Leave empty ("") for default sounds.
 restock-sound: ""
 
 #The sound played when a villager is leveled up. Leave empty ("") for no sound.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,7 +17,7 @@ only-lobotomize-villagers-with-professions: false
 always-lobotomize-villagers-in-vehicles: false
 
 #The sound to play when a villager restocks. Leave empty ("") for no sound.
-restock-sound: "ENTITY_VILLAGER_CELEBRATE"
+restock-sound: ""
 
 #The sound played when a villager is leveled up. Leave empty ("") for no sound.
 level-up-sound: "ENTITY_VILLAGER_CELEBRATE"


### PR DESCRIPTION
Currently villagers only use a singular config celebrate sound when restocking, so I added the option to change to vanilla (sound depending on their job site block) if the specified config value is empty `""`

#13 
