### PR TITLE
feat: color villagers in debug mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Build Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: 'gradle'
+          
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build --no-daemon
+      
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: build-artifacts
+        path: build/libs/
+        retention-days: 7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "dev.mja00"
-version = "1.9.2"
+version = "1.9.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -203,7 +203,9 @@ public class LobotomizeStorage {
     public final void flush() {
         // We'll flush all the villagers before shutdown, so if the plugin is removed, they won't have lobotomized villagers forever
         this.inactiveVillagers.removeIf((villager) -> {
-            this.logger.info("Un-lobotomizing Villager " + villager.getUniqueId());
+            if (this.plugin.isDebugging()) {
+                this.logger.info("Un-lobotomizing Villager " + villager.getUniqueId());
+            }
             villager.setAware(true);
             return true;
         });
@@ -233,6 +235,10 @@ public class LobotomizeStorage {
                 }
                 return true; // Remove from inactive list
             }
+            if (this.plugin.isDebugging() && this.plugin.getActiveVillagersTeam() != null) {
+                this.plugin.getActiveVillagersTeam().addEntity(villager);
+                villager.setGlowing(true);
+            }
             return false; // Already active
         } else {
             // Refresh any trades as this villager is inactive
@@ -246,6 +252,10 @@ public class LobotomizeStorage {
                 }
                 return true; // Remove from active
             }
+            if (this.plugin.isDebugging() && this.plugin.getInactiveVillagersTeam() != null) {
+                this.plugin.getInactiveVillagersTeam().addEntity(villager);
+                villager.setGlowing(true);
+            }
             return false;
         }
     }
@@ -255,6 +265,7 @@ public class LobotomizeStorage {
             // It's night, do not refresh trades
             return;
         }
+
 
         if (!VillagerUtils.isJobSiteNearby(villager)) {
             return;

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -4,12 +4,18 @@ import com.google.gson.Gson;
 import dev.mja00.villagerLobotomizer.listeners.EntityListener;
 import dev.mja00.villagerLobotomizer.objects.Modrinth;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.MultiLineChart;
 import org.bstats.charts.SingleLineChart;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Villager;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.scoreboard.Team;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -18,6 +24,7 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +37,10 @@ public final class VillagerLobotomizer extends JavaPlugin {
     static final HttpClient client = HttpClient.newHttpClient();
     static final Gson gson = new Gson();
     public boolean needsUpdate = false;
+    public Team activeVillagersTeam;
+    public Team inactiveVillagersTeam;
+    private final String activeVillagersTeamName = "lobotomy_active_villagers";
+    private final String inactiveVillagersTeamName = "lobotomy_inactive_villagers";
 
     @Override
     public void onEnable() {
@@ -44,6 +55,7 @@ public final class VillagerLobotomizer extends JavaPlugin {
         // Set our debugs based on the config
         this.debugging = this.getConfig().getBoolean("debug");
         this.chunkDebugging = this.getConfig().getBoolean("chunk-debug");
+        boolean createDebuggingTeams = this.getConfig().getBoolean("create-debug-teams", false);
 
         Metrics metrics = new Metrics(this, 25704);
 
@@ -66,7 +78,31 @@ public final class VillagerLobotomizer extends JavaPlugin {
         getLogger().info("I'm ready to lobotomize your villagers!");
         if (this.isDebugging()) {
             getLogger().info("Debug mode is enabled. This will print debug messages to the console.");
+            // Ensure two teams are created for debugging purposes, active and inactive villagers
+            // Colors for the teams are green and red respectively
+            // This way we can toggle glow on them in debug mode
+            if (createDebuggingTeams) {
+                createDebuggingTeams();
+            }
         }
+    }
+
+    private void createDebuggingTeams() {
+        ScoreboardManager scoreboardManager = this.getServer().getScoreboardManager();
+        Team activeTeam = scoreboardManager.getMainScoreboard().getTeam(this.activeVillagersTeamName);
+        if (activeTeam == null) {
+            activeTeam = scoreboardManager.getMainScoreboard().registerNewTeam(this.activeVillagersTeamName);
+            activeTeam.displayName(Component.text("Active Villagers"));
+            activeTeam.color(NamedTextColor.GREEN);
+        }
+        Team inactiveTeam = scoreboardManager.getMainScoreboard().getTeam(this.inactiveVillagersTeamName);
+        if (inactiveTeam == null) {
+            inactiveTeam = scoreboardManager.getMainScoreboard().registerNewTeam(this.inactiveVillagersTeamName);
+            inactiveTeam.displayName(Component.text("Inactive Villagers"));
+            inactiveTeam.color(NamedTextColor.RED);
+        }
+        this.activeVillagersTeam = activeTeam;
+        this.inactiveVillagersTeam = inactiveTeam;
     }
 
     private void setupMetrics(Metrics metrics) {
@@ -95,6 +131,31 @@ public final class VillagerLobotomizer extends JavaPlugin {
         if (this.storage != null) {
             this.storage.flush();
         }
+        // If either of the teams are not null, we need to remove them
+        Team activeTeam = this.getServer().getScoreboardManager().getMainScoreboard().getTeam(this.activeVillagersTeamName);
+        clearTeam(activeTeam);
+        Team inactiveTeam = this.getServer().getScoreboardManager().getMainScoreboard().getTeam(this.inactiveVillagersTeamName);
+        clearTeam(inactiveTeam);
+    }
+
+    private void clearTeam(Team team) {
+        if (team != null) {
+            // Get all entities on the team and unglow them just in case
+            for (String entry : team.getEntries()) {
+                UUID uuid = UUID.fromString(entry);
+                Entity entity = this.getServer().getEntity(uuid);
+                if (entity instanceof Villager) {
+                    entity.setGlowing(false);
+                    team.removeEntity(entity);
+                }
+            }
+            try {
+                team.unregister();
+            } catch (IllegalStateException e) {
+                // This can happen if the team is already unregistered, we can safely ignore this
+                this.getLogger().warning("Failed to unregister team " + team.getName() + ": " + e.getMessage());
+            }
+        }
     }
 
     public boolean isDebugging() {
@@ -103,6 +164,16 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
     public void setDebugging(boolean debugging) {
         this.debugging = debugging;
+        // If debugging is being set to false, we need to clean up the teams
+        if (!debugging) {
+            Team activeTeam = this.getServer().getScoreboardManager().getMainScoreboard().getTeam(this.activeVillagersTeamName);
+            clearTeam(activeTeam);
+            Team inactiveTeam = this.getServer().getScoreboardManager().getMainScoreboard().getTeam(this.inactiveVillagersTeamName);
+            clearTeam(inactiveTeam);
+        } else {
+            // Create them again
+            createDebuggingTeams();
+        }
         // Update the config
         this.getConfig().set("debug", this.debugging);
         this.saveConfig();
@@ -160,5 +231,13 @@ public final class VillagerLobotomizer extends JavaPlugin {
                 this.getLogger().info("You are running the latest version of VillagerLobotomizer.");
             }
         });
+    }
+
+    public Team getActiveVillagersTeam() {
+        return this.activeVillagersTeam;
+    }
+
+    public Team getInactiveVillagersTeam() {
+        return this.inactiveVillagersTeam;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,3 +36,6 @@ ignore-non-solid-blocks: false
 
 #To check if there is a roof above a villager before lobotomizing, set this to true
 check-roof: true
+
+#Create teams for debugging purposes. This will create colored teams for inactive and active villagers. We use this to color their glowing effect.
+create-debug-teams: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: VillagerLobotimizer
-version: '1.9.2'
+version: '1.9.3'
 main: dev.mja00.villagerLobotomizer.VillagerLobotomizer
 api-version: '1.21'
 authors: [ mja00, DereC4 ]


### PR DESCRIPTION
This should color villagers in debug mode (and teams enabled) with their status. This'll help quickly identify what state a villager is in. 

@DereC4 can you test this out for me with your big villager trading hall? Should just need to set `create-debug-teams` to true in the config and toggle debug mode to on. 