### PR TITLE
feat: attempt to add Folia support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.mja00"
-version = "1.10.6"
+version = "1.11.0"
 
 repositories {
     mavenCentral()
@@ -20,6 +20,10 @@ repositories {
         name = "sonatype"
         url = uri("https://oss.sonatype.org/content/groups/public/")
     }
+    maven {
+        name = "tcoded-releases"
+        url = uri("https://repo.tcoded.com/releases")
+    }
     gradlePluginPortal()
 }
 
@@ -27,6 +31,7 @@ dependencies {
     paperweight.paperDevBundle("1.21.6-R0.1-SNAPSHOT")
     implementation("net.kyori:adventure-text-serializer-plain:4.22.0")
     implementation(group = "org.bstats", name = "bstats-bukkit", version = "3.1.0")
+    implementation("com.tcoded:FoliaLib:0.5.1")
 }
 
 val targetJavaVersion = 21
@@ -72,7 +77,9 @@ tasks {
     }
 
     shadowJar {
-        minimize()
+        minimize {
+            exclude(dependency("com.tcoded:FoliaLib:.*"))
+        }
 
         archiveClassifier = null
         archiveVersion = project.version.toString()
@@ -80,9 +87,11 @@ tasks {
         dependencies {
             include(dependency("org.bstats:bstats-bukkit"))
             include(dependency("org.bstats:bstats-base"))
+            include(dependency("com.tcoded:FoliaLib"))
         }
 
         relocate("org.bstats", "dev.mja00.villagerLobotomizer.bstats")
+        relocate("com.tcoded.folialib", "dev.mja00.villagerLobotomizer.lib.folialib")
     }
 }
 
@@ -155,7 +164,7 @@ modrinth {
 
     uploadFile.set(tasks.shadowJar.flatMap { it.archiveFile })
     gameVersions.set(modrinthGameVersions)
-    loaders.set(listOf("paper", "purpur"))
+    loaders.set(listOf("paper", "purpur", "folia"))
 }
 
 // Add explicit dependency for the publish task

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,10 +20,6 @@ repositories {
         name = "sonatype"
         url = uri("https://oss.sonatype.org/content/groups/public/")
     }
-    maven {
-        name = "tcoded-releases"
-        url = uri("https://repo.tcoded.com/releases")
-    }
     gradlePluginPortal()
 }
 
@@ -31,7 +27,6 @@ dependencies {
     paperweight.paperDevBundle("1.21.6-R0.1-SNAPSHOT")
     implementation("net.kyori:adventure-text-serializer-plain:4.22.0")
     implementation(group = "org.bstats", name = "bstats-bukkit", version = "3.1.0")
-    implementation("com.tcoded:FoliaLib:0.5.1")
 }
 
 val targetJavaVersion = 21
@@ -77,9 +72,7 @@ tasks {
     }
 
     shadowJar {
-        minimize {
-            exclude(dependency("com.tcoded:FoliaLib:.*"))
-        }
+        minimize()
 
         archiveClassifier = null
         archiveVersion = project.version.toString()
@@ -87,11 +80,9 @@ tasks {
         dependencies {
             include(dependency("org.bstats:bstats-bukkit"))
             include(dependency("org.bstats:bstats-base"))
-            include(dependency("com.tcoded:FoliaLib"))
         }
 
         relocate("org.bstats", "dev.mja00.villagerLobotomizer.bstats")
-        relocate("com.tcoded.folialib", "dev.mja00.villagerLobotomizer.lib.folialib")
     }
 }
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.MultiLineChart;
+import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
@@ -178,6 +179,7 @@ public final class VillagerLobotomizer extends JavaPlugin {
         metrics.addCustomChart(new SingleLineChart("active_villagers", () -> getStorage().getActive().size()));
         metrics.addCustomChart(new SingleLineChart("inactive_villagers", () -> getStorage().getLobotomized().size()));
         metrics.addCustomChart(new SingleLineChart("total_villagers", () -> getStorage().getActive().size() + getStorage().getLobotomized().size()));
+        metrics.addCustomChart(new SimplePie("is_folia", () -> this.isFolia ? "yes" : "no"));
     }
 
     @Override

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: VillagerLobotimizer
-version: '1.10.6'
+version: '1.11.0'
 main: dev.mja00.villagerLobotomizer.VillagerLobotomizer
 api-version: '1.21.6'
 authors: [ mja00, DereC4 ]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,10 +1,11 @@
 name: VillagerLobotimizer
-version: '1.10.6'
+version: '1.11.0'
 main: dev.mja00.villagerLobotomizer.VillagerLobotomizer
 api-version: '1.21.6'
 authors: [ mja00, DereC4 ]
 description: A plugin that turns off Villager's brains when they're stuck in a trading hall.
 website: https://github.com/mja00/VillagerLobotimizer
+folia-supported: true
 permissions:
   lobotomy.command:
     description: "Allows the use of the lobotomy command"


### PR DESCRIPTION
In Paper basically everything just hits the main thread, whereas in Folia it'll use entity schedulers for any Villager mutations. 

Also added some failsafes/try-catches to areas where we can't use a scheduler (such as storage flushing) in hopes of not throwing exceptions. 