### PR TITLE
refactor: more friendly implementation for preventing trading with unlobotomized villagers

### DIFF
--- a/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
@@ -3,7 +3,6 @@ package dev.mja00.villagerLobotomizer.listeners;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -13,11 +12,11 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.MerchantInventory;
 
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
@@ -96,74 +95,56 @@ public class EntityListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public final void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+    public final void onInventoryOpen(InventoryOpenEvent event) {
         // Check if the feature is enabled in config
         if (!this.plugin.getConfig().getBoolean("prevent-trading-with-unlobotomized-villagers", false)) {
             return;
         }
 
-        // Only handle villager interactions
-        if (!(event.getRightClicked() instanceof Villager villager)) {
+        // Only handle merchant inventories
+        Inventory inventory = event.getInventory();
+        if (!(inventory instanceof MerchantInventory merchantInventory)) {
             return;
         }
 
-        Player player = event.getPlayer();
-
-        // If the player has a nametag in their hand (either) they're not trying to trade and are trying to name it
-        ItemStack itemInMainHand = player.getInventory().getItemInMainHand();
-        ItemStack itemInOffHand = player.getInventory().getItemInOffHand();
-        
-        // Check if either hand has a nametag
-        ItemStack nametagItem = null;
-        if (itemInMainHand.getType() == Material.NAME_TAG) {
-            nametagItem = itemInMainHand;
-        } else if (itemInOffHand.getType() == Material.NAME_TAG) {
-            nametagItem = itemInOffHand;
-        }
-        
-        if (nametagItem != null) {
-            // Check if the nametag has a custom display name
-            ItemMeta meta = nametagItem.getItemMeta();
-            if (meta != null && meta.hasDisplayName()) {
-                // Nametag has a custom name, allow the interaction
+        // Get the merchant (entity) from the merchant inventory
+        Villager villager;
+        try {
+            // MerchantInventory.getMerchant() may not be directly accessible, try to get from the holder
+            Object holder = merchantInventory.getHolder();
+            if (!(holder instanceof Villager)) {
                 return;
             }
-            // Otherwise do nothing and let the code continue
-        }
-
-        // Check if the villager is tracked by the plugin
-        boolean isTrackedActive = this.plugin.getStorage().getActive().contains(villager);
-        boolean isTrackedInactive = this.plugin.getStorage().getLobotomized().contains(villager);
-        
-        // If the villager is not tracked at all, allow trading (default behavior)
-        if (!isTrackedActive && !isTrackedInactive) {
+            villager = (Villager) holder;
+        } catch (Exception e) {
+            // If we can't get the villager, allow the event
             return;
         }
-        
-        // Block trades only with unlobotomized (active) villagers
-        if (isTrackedActive) {
-            // Cancel the trading event
-            event.setCancelled(true);
-            
-            // Send a message to the player explaining why the trade was blocked
-            String messageString = this.plugin.getConfig().getString("unlobotomized-villager-trade-message", 
-                    "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>");
-            if (messageString == null) {
-                messageString = "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>";
-            }
-            Component message;
-            try {
-                message = MINI_MESSAGE.deserialize(messageString);
-            } catch (Exception e) {
-                // Fallback to default message if parsing fails
-                this.plugin.getLogger().log(Level.WARNING, "Failed to parse MiniMessage for unlobotomized-villager-trade-message: {0}", e.getMessage());
-                message = MINI_MESSAGE.deserialize("<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>");
-            }
-            player.sendMessage(message);
-            
-            if (this.plugin.isDebugging()) {
-                this.plugin.getLogger().log(Level.INFO, "[Debug] Blocked trade with unlobotomized villager {0} by player {1}", new Object[]{villager.getUniqueId(), player.getName()});
-            }
+
+        // Check if the villager is tracked by the plugin as active (unlobotomized)
+        if (!this.plugin.getStorage().getActive().contains(villager)) {
+            return;
+        }
+
+        // Block the inventory opening event
+        Player player = (Player) event.getPlayer();
+        event.setCancelled(true);
+
+        // Send a message to the player explaining why the trade was blocked
+        String messageString = this.plugin.getConfig().getString("unlobotomized-villager-trade-message",
+                "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>");
+        Component message;
+        try {
+            message = MINI_MESSAGE.deserialize(messageString);
+        } catch (Exception e) {
+            // Fallback to default message if parsing fails
+            this.plugin.getLogger().log(Level.WARNING, "Failed to parse MiniMessage for unlobotomized-villager-trade-message: {0}", e.getMessage());
+            message = MINI_MESSAGE.deserialize("<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>");
+        }
+        player.sendMessage(message);
+
+        if (this.plugin.isDebugging()) {
+            this.plugin.getLogger().log(Level.INFO, "[Debug] Blocked trade with unlobotomized villager {0} by player {1}", new Object[]{villager.getUniqueId(), player.getName()});
         }
     }
 }


### PR DESCRIPTION
Previously, the code listens to PlayerInteractEntityEvent, which covers too much cases than we actually need to deal with, and we need to take care of the name tag logic. By listening to InventoryOpenEvent, the code handles exactly what we need to deal with - to prevent trading with unlobotomized villagers. No more other bandaid logic.