### PR TITLE
ci: add arc-smoke workflow for self-hosted runner validation

### DIFF
--- a/.github/workflows/arc-smoke.yml
+++ b/.github/workflows/arc-smoke.yml
@@ -1,0 +1,24 @@
+name: arc-smoke
+
+# Manual smoke test for the self-hosted ARC runner scale set (arc-villager).
+# Safe to delete once the runner is proven; not wired to push/PR.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello:
+    runs-on: arc-villager
+    steps:
+      - name: Print runner identity
+        run: |
+          echo "Hostname: $(hostname)"
+          echo "Kernel:   $(uname -a)"
+          echo "User:     $(id)"
+          echo "Workdir:  $(pwd)"
+          echo "Disk:"
+          df -h /
+      - name: Confirm DinD sidecar reachable
+        run: |
+          docker info | head -20
+          docker run --rm hello-world


### PR DESCRIPTION
## Summary
- adds `.github/workflows/arc-smoke.yml`: manual `workflow_dispatch` smoke test that runs on the new self-hosted ARC scale set `arc-villager`
- prints runner identity (hostname/kernel/disk) and verifies the DinD sidecar is reachable via `docker info` + `docker run hello-world`
- safe to delete once the cluster's `arc-villager` runners are proven

## Test plan
- [ ] merge PR, then trigger via `gh workflow run arc-smoke.yml` (or the GitHub UI)
- [ ] runner pod spawns in the cluster, lands on the `gemini` worker (role-builder)
- [ ] job logs show docker working through the DinD sidecar
- [ ] runner pod cleaned up after the job completes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mja00/codesmith/VillagerLobotimizer/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->