### PR TITLE
Code review remediation: Folia safety, correctness, performance + activity-policy extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,15 +22,19 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 **LobotomizeStorage.java** - Core logic:
 - Sets: `activeVillagers`, `inactiveVillagers`
 - Maps: `villagerTasks` (UUID→Task), `changedChunks`, `villagerTaskIntervals`
-- Lobotomy logic: name overrides ("nobrain" forces, exempt names prevent), water check, vehicle check, profession check, `canMoveCardinally()` movement check, optional roof check
+- Lobotomy decision delegated to `policy.VillagerActivityPolicy` (name overrides "nobrain"/exempt, water/vehicle/profession checks, movement check, optional roof check); `LobotomizeStorage` adapts a live `Villager`/`World` into `VillagerState`/`BlockGrid` per check (`villagerStateOf`, `gridOf`)
 - Trade refresh: PDC-tracked restock timing, daytime-only, job site proximity, profession sounds, level-up effects
-- Block sets: `IMPASSABLE_REGULAR` (occluding+lava), `IMPASSABLE_FLOOR` (carpets), `IMPASSABLE_TALL` (walls/fences), `PROFESSION_BLOCKS` (workstations), `DOOR_BLOCKS`
 
-**EntityListener.java** - Events: `EntityAddToWorldEvent`, `EntityRemoveFromWorldEvent`, `BlockBreakEvent/PlaceEvent` (chunk updates), `PlayerInteractEntityEvent` (optional trade prevention)
+**policy/** - Pure, unit-tested lobotomy decision logic (no Bukkit live objects, scheduler, or shared sets):
+- `VillagerActivityPolicy.shouldBeActive(VillagerState, BlockGrid)` - decision rules + `canMoveCardinally`/`canMoveThrough`/`testImpassable`
+- `BlockClassifier` - Material sets (`impassableRegular`, `impassableTall`, `impassableAll`, `cropBlocks`, `doorBlocks`, `professionBlocks`), built once via `fromServerRegistry()`
+- `BlockSnapshot` (type/passable/solid), `BlockGrid` (coord→snapshot, `null`=unloaded), `VillagerState` (villager properties)
+
+**EntityListener.java** - Events: `EntityAddToWorldEvent`, `EntityRemoveFromWorldEvent`, `BlockBreakEvent/PlaceEvent` (chunk updates), `InventoryOpenEvent` (optional trade prevention via merchant-inventory check)
 
 **LobotomizeCommand.java** - Brigadier commands registered via `LifecycleEvents.COMMANDS`, permission `lobotomy.command` (op), raycasting for targeting. Wake command clears `isLobotomized` PDC marker.
 
-**VillagerUtils.java** - Maps: `PROFESSION_TO_WORKSTATION`, `PROFESSION_TO_SOUND`. Methods: `isJobSiteNearby()` (48 blocks), `shouldRestock()` (PDC+day-time logic)
+**VillagerUtils.java** - Maps: `PROFESSION_TO_STATION`, `PROFESSION_TO_SOUND`. Methods: `isJobSiteNearby()` (3x3x3 box), `shouldRestock()` (PDC+day-time logic)
 
 ### Config (read in constructors)
 `check-interval`, `inactive-check-interval`, `restock-interval`, `restock-random-range`, `restock-sound`, `level-up-sound`, `debug`, `chunk-debug`, `create-debug-teams` (Folia-incompatible), `check-roof`, `ignore-non-solid-blocks`, `disable-chunk-villager-updates`, `persist-lobotomized-state`
@@ -38,8 +42,7 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 ### PDC Keys
 - `lastRestock` (LONG): Last trade refresh timestamp
 - `isLobotomized` (BYTE): Persistence marker (when `persist-lobotomized-state: true`)
-- `lastRestockGameTime` (LONG): Game time at last restock
-- `lastRestockCheckDayTime` (LONG): Day time at last restock check
+- `lastRestockCheckDayTime` (LONG): Full game time (absolute ticks) at last restock check; used for day-rollover detection
 
 ## Development
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.mja00"
-version = "1.14.2"
+version = "1.15.0"
 
 repositories {
     mavenCentral()
@@ -71,7 +71,7 @@ tasks {
 
     runServer {
         dependsOn(shadowJar)
-        minecraftVersion("26.1.2")
+        minecraftVersion("26.2")
 
         // Set system property to mark this as a development environment for Sentry
         systemProperty("villagerlobotimizer.dev", "true")
@@ -114,10 +114,10 @@ tasks {
 }
 
 // Planning on using API only available in 1.21.6 (and technically 1.21.5 but only the last like 10 builds)
-val supportedVersions = listOf("1.21.6-26.1.2")
+val supportedVersions = listOf("1.21.6-26.2")
 
 // Modrinth requires discrete game versions rather than a range
-val modrinthGameVersions = listOf("1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11", "26.1", "26.1.1", "26.1.2")
+val modrinthGameVersions = listOf("1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11", "26.1", "26.1.1", "26.1.2", "26.2")
 
 hangarPublish {
     publications.register("plugin") {

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
@@ -101,7 +101,6 @@ public class LobotomizeCommand {
     }
 
     private int debugCommand(CommandSourceStack source) throws CommandSyntaxException {
-        // If the command isn't executed by a player, we don't want to do anything
         Entity target = getLookedTarget(source);
         if (target == null) return 0;
         return this.getVillagerDetails(source, (Villager) target);
@@ -122,7 +121,6 @@ public class LobotomizeCommand {
     }
 
     private int debugCommandSpecific(CommandSourceStack source, EntitySelectorArgumentResolver resolver) throws CommandSyntaxException {
-        // If the command isn't executed by a player, we don't want to do anything
         if (!(source.getExecutor() instanceof Player)) {
             source.getSender().sendMessage(Component.text("Only players can use this command."));
             return 0;
@@ -142,7 +140,7 @@ public class LobotomizeCommand {
     private int getVillagerDetails(CommandSourceStack source, Villager villager) {
         boolean lobotomized = this.plugin.getStorage().getLobotomized().contains(villager);
         boolean active = this.plugin.getStorage().getActive().contains(villager);
-        // If they aren't aware we should ignore the hasAI call
+        // isAware false implies no AI regardless of hasAI
         boolean hasAI = villager.isAware() && villager.hasAI();
         Component message = Component.text("Is Awareness enabled: ")
                 .append(Component.text(villager.isAware()).color(villager.isAware() ? NamedTextColor.GREEN : NamedTextColor.RED));
@@ -171,7 +169,6 @@ public class LobotomizeCommand {
     }
 
     private int wakeCommand(CommandSourceStack source) throws CommandSyntaxException {
-        // If the command isn't executed by a player, we don't want to do anything
         Entity target = getLookedTarget(source);
         if (target == null) return 0;
         Villager villager = (Villager) target;
@@ -213,12 +210,10 @@ public class LobotomizeCommand {
             return builder.buildFuture();
         }
 
-        // Get all config keys dynamically from the config
         Set<String> configKeys = plugin.getConfig().getKeys(true);
 
         String remaining = builder.getRemaining().toLowerCase();
 
-        // Filter and suggest keys that match the input
         configKeys.stream()
                 .filter(key -> key.toLowerCase().startsWith(remaining))
                 .forEach(builder::suggest);
@@ -233,7 +228,6 @@ public class LobotomizeCommand {
     }
 
     private int setConfigCommand(CommandSourceStack source, String key, String value) throws CommandSyntaxException {
-        // Check if the key exists in the config
         if (!this.plugin.getConfig().contains(key)) {
             source.getSender().sendMessage(Component.text("Config key '" + key + "' does not exist.").color(NamedTextColor.RED));
             return 0;
@@ -243,9 +237,7 @@ public class LobotomizeCommand {
         Object currentValue = this.plugin.getConfig().get(key);
 
         try {
-            // Determine the type and set the value accordingly
             if (currentValue instanceof Boolean) {
-                // Boolean values
                 if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
                     source.getSender().sendMessage(Component.text("'" + key + "' expects a boolean value (true/false), but got: " + value).color(NamedTextColor.RED));
                     return 0;
@@ -264,23 +256,19 @@ public class LobotomizeCommand {
                     this.plugin.getConfig().set(key, parsed);
                 }
             } else if (currentValue instanceof String) {
-                // String values
                 this.plugin.getConfig().set(key, value);
             } else if (currentValue instanceof List) {
-                // List values - for now, we'll treat this as adding to the list
+                // List editing unsupported via command
                 source.getSender().sendMessage(Component.text("Setting list values is not supported yet. Use the config file directly.").color(NamedTextColor.YELLOW));
                 return 0;
             } else {
-                // Unknown type
                 source.getSender().sendMessage(Component.text("Cannot set value for '" + key + "': unsupported type.").color(NamedTextColor.RED));
                 return 0;
             }
 
-            // Save the config
             this.plugin.saveConfig();
             this.plugin.reloadConfig();
 
-            // Send success message
             source.getSender().sendMessage(Component.text("Successfully set '" + key + "' to '" + value + "'").color(NamedTextColor.GREEN));
             source.getSender().sendMessage(Component.text("Note: You may need to run '/lobotomy reload' for changes to take effect.").color(NamedTextColor.YELLOW));
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
@@ -73,6 +73,11 @@ public class LobotomizeCommand {
                 || sender.hasPermission("lobotomy.command.config");
     }
 
+    /**
+     * Displays statistics about tracked villagers on the server.
+     *
+     * @return Command.SINGLE_SUCCESS
+     */
     private int infoCommand(CommandSourceStack source) throws CommandSyntaxException {
         int active = this.plugin.getStorage().getActive().size();
         int inactive = this.plugin.getStorage().getLobotomized().size();
@@ -100,13 +105,24 @@ public class LobotomizeCommand {
         return Command.SINGLE_SUCCESS;
     }
 
+    /**
+     * Displays debug information about the villager the executor is looking at.
+     *
+     * @return 0 if no villager is targeted; otherwise Command.SINGLE_SUCCESS
+     * @throws CommandSyntaxException if a command syntax error occurs
+     */
     private int debugCommand(CommandSourceStack source) throws CommandSyntaxException {
         Entity target = getLookedTarget(source);
         if (target == null) return 0;
         return this.getVillagerDetails(source, (Villager) target);
     }
 
-    // This ensures the executor is a player and that they are looking at a villager
+    /**
+     * Retrieves the villager the command executor is looking at.
+     *
+     * @param  source the command source stack
+     * @return the villager being looked at, or null if the executor is not a player or no villager is targeted
+     */
     private @Nullable Entity getLookedTarget(CommandSourceStack source) {
         if (!(source.getExecutor() instanceof Player player)) {
             source.getSender().sendMessage(Component.text("Only players can use this command."));
@@ -120,6 +136,12 @@ public class LobotomizeCommand {
         return target;
     }
 
+    /**
+     * Displays the details of a villager selected via entity selector.
+     *
+     * @return {@code Command.SINGLE_SUCCESS} if the villager details are displayed, {@code 0} otherwise.
+     * @throws CommandSyntaxException if entity selection fails.
+     */
     private int debugCommandSpecific(CommandSourceStack source, EntitySelectorArgumentResolver resolver) throws CommandSyntaxException {
         if (!(source.getExecutor() instanceof Player)) {
             source.getSender().sendMessage(Component.text("Only players can use this command."));
@@ -137,6 +159,11 @@ public class LobotomizeCommand {
         return getVillagerDetails(source, villager);
     }
 
+    /**
+     * Sends detailed status information about a villager to the command source.
+     *
+     * @return {@code Command.SINGLE_SUCCESS}
+     */
     private int getVillagerDetails(CommandSourceStack source, Villager villager) {
         boolean lobotomized = this.plugin.getStorage().getLobotomized().contains(villager);
         boolean active = this.plugin.getStorage().getActive().contains(villager);
@@ -159,6 +186,11 @@ public class LobotomizeCommand {
         return Command.SINGLE_SUCCESS;
     }
 
+    /**
+     * Finds the villager the player is looking at within 16 blocks.
+     *
+     * @return the villager in the player's line of sight, or {@code null} if none is targeted
+     */
     private @Nullable Entity getTargeted(Player player) {
         Entity target = null;
 
@@ -168,6 +200,11 @@ public class LobotomizeCommand {
         return target;
     }
 
+    /**
+     * Removes a targeted villager from plugin tracking and clears its lobotomized marker.
+     *
+     * @return the command status code; 1 on successful removal, 0 if no villager target was found
+     */
     private int wakeCommand(CommandSourceStack source) throws CommandSyntaxException {
         Entity target = getLookedTarget(source);
         if (target == null) return 0;
@@ -199,6 +236,11 @@ public class LobotomizeCommand {
         return Command.SINGLE_SUCCESS;
     }
 
+    /**
+     * Provides suggestions for config keys matching the partially-typed input.
+     *
+     * @return suggestions for matching config keys
+     */
     private static CompletableFuture<Suggestions> getConfigKeySuggestions(final CommandContext<CommandSourceStack> ctx, final SuggestionsBuilder builder) {
         CommandSourceStack source = ctx.getSource();
         if (!(source.getExecutor() instanceof Player)) {
@@ -221,12 +263,28 @@ public class LobotomizeCommand {
         return builder.buildFuture();
     }
 
+    /**
+     * Retrieves and displays a configuration value.
+     *
+     * @param key the configuration key to retrieve
+     * @return the command result code
+     */
     private int getConfigCommand(CommandSourceStack source, String key) throws CommandSyntaxException {
         String value = this.plugin.getConfig().getString(key);
         source.getSender().sendMessage(Component.text("The value of " + key + " is " + value));
         return Command.SINGLE_SUCCESS;
     }
 
+    /**
+     * Sets a configuration value by parsing and validating the input string according to the expected type.
+     * Saves the modified configuration and reloads it on success.
+     *
+     * @param key the config key to modify
+     * @param value the value as a string to set
+     * @return {@code Command.SINGLE_SUCCESS} if the value is successfully set; {@code 0}
+     *         if the key does not exist, the value type is unsupported or unrecognized,
+     *         the input is invalid for the expected type, or a parsing error occurs
+     */
     private int setConfigCommand(CommandSourceStack source, String key, String value) throws CommandSyntaxException {
         if (!this.plugin.getConfig().contains(key)) {
             source.getSender().sendMessage(Component.text("Config key '" + key + "' does not exist.").color(NamedTextColor.RED));

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -2,7 +2,6 @@ package dev.mja00.villagerLobotomizer;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -24,8 +23,6 @@ import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.Ageable;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.Villager;
@@ -37,6 +34,11 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
+import dev.mja00.villagerLobotomizer.policy.BlockClassifier;
+import dev.mja00.villagerLobotomizer.policy.BlockGrid;
+import dev.mja00.villagerLobotomizer.policy.BlockSnapshot;
+import dev.mja00.villagerLobotomizer.policy.VillagerActivityPolicy;
+import dev.mja00.villagerLobotomizer.policy.VillagerState;
 import dev.mja00.villagerLobotomizer.utils.SentryTaskWrapper;
 import dev.mja00.villagerLobotomizer.utils.StringUtils;
 import dev.mja00.villagerLobotomizer.utils.VillagerUtils;
@@ -47,92 +49,13 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 public class LobotomizeStorage {
-    /**
-     * IMPASSABLE_REGULAR is a set of blocks that are occulding light (so most solid blocks)
-     */
-    private static final EnumSet<Material> IMPASSABLE_REGULAR;
-    /**
-     * IMPASSABLE_FLOOR is a set of carpets types
-     */
-    private static final EnumSet<Material> IMPASSABLE_FLOOR;
-    /**
-     * IMPASSABLE_TALL is a set of blocks that are tall (so walls and fences)
-     */
-    private static final EnumSet<Material> IMPASSABLE_TALL;
-    /**
-     * IMPASSABLE_ALL is a set of all the impassable blocks
-     */
-    private static final EnumSet<Material> IMPASSABLE_ALL;
-    /**
-     * IMPASSABLE_REGULAR_FLOOR is a set of blocks that are regular and floor
-     */
-    private static final EnumSet<Material> IMPASSABLE_REGULAR_FLOOR;
-    /**
-     * IMPASSABLE_REGULAR_TALL is a set of blocks that are regular and tall
-     */
-    private static final EnumSet<Material> IMPASSABLE_REGULAR_TALL;
-    /**
-     * PROFESSION_BLOCKS is a set of blocks that are profession blocks
-     */
-    private static final EnumSet<Material> PROFESSION_BLOCKS;
-    private static final EnumSet<Material> DOOR_BLOCKS;
-
-    static {
-        IMPASSABLE_REGULAR = EnumSet.of(Material.LAVA);
-        IMPASSABLE_FLOOR = EnumSet.noneOf(Material.class);
-        IMPASSABLE_TALL = EnumSet.noneOf(Material.class);
-        DOOR_BLOCKS = EnumSet.noneOf(Material.class);
-        for (Material m : Registry.MATERIAL) {
-            if (m.isOccluding()) {
-                IMPASSABLE_REGULAR.add(m);
-            }
-
-            if (m.name().contains("_CARPET")) {
-                IMPASSABLE_FLOOR.add(m);
-            }
-
-            if (m.name().contains("_WALL") || m.name().contains("_FENCE")) {
-                IMPASSABLE_TALL.add(m);
-            }
-
-            if (m.name().contains("_DOOR")) {
-                DOOR_BLOCKS.add(m);
-            }
-        }
-
-        IMPASSABLE_ALL = EnumSet.copyOf(IMPASSABLE_REGULAR);
-        IMPASSABLE_REGULAR_FLOOR = EnumSet.copyOf(IMPASSABLE_REGULAR);
-        IMPASSABLE_REGULAR_TALL = EnumSet.copyOf(IMPASSABLE_REGULAR);
-        IMPASSABLE_ALL.addAll(IMPASSABLE_FLOOR);
-        IMPASSABLE_ALL.addAll(IMPASSABLE_TALL);
-        IMPASSABLE_REGULAR_FLOOR.addAll(IMPASSABLE_FLOOR);
-        IMPASSABLE_REGULAR_TALL.addAll(IMPASSABLE_TALL);
-
-        // Create a list of blocks that are profession blocks
-        PROFESSION_BLOCKS = EnumSet.noneOf(Material.class);
-        PROFESSION_BLOCKS.add(Material.BLAST_FURNACE);
-        PROFESSION_BLOCKS.add(Material.SMOKER);
-        PROFESSION_BLOCKS.add(Material.CARTOGRAPHY_TABLE);
-        PROFESSION_BLOCKS.add(Material.BREWING_STAND);
-        PROFESSION_BLOCKS.add(Material.COMPOSTER);
-        PROFESSION_BLOCKS.add(Material.BARREL);
-        PROFESSION_BLOCKS.add(Material.FLETCHING_TABLE);
-        PROFESSION_BLOCKS.add(Material.CAULDRON);
-        PROFESSION_BLOCKS.add(Material.LECTERN);
-        PROFESSION_BLOCKS.add(Material.STONECUTTER);
-        PROFESSION_BLOCKS.add(Material.LOOM);
-        PROFESSION_BLOCKS.add(Material.SMITHING_TABLE);
-        PROFESSION_BLOCKS.add(Material.GRINDSTONE);
-    }
-
     private final VillagerLobotomizer plugin;
     private final NamespacedKey key;
     private final NamespacedKey lobotomizedKey;
+    private final NamespacedKey lastRestockCheckDayTimeKey;
     private final Set<Villager> activeVillagers = Collections.newSetFromMap(new ConcurrentHashMap<>(128));
     private final Set<Villager> inactiveVillagers = Collections.newSetFromMap(new ConcurrentHashMap<>(128));
-    // Used to track what chunks we need to trigger updates for
     private final Map<Chunk, Long> changedChunks = new ConcurrentHashMap<>();
-    // Track per-villager scheduled tasks using Paper's native schedulers
     private final Map<UUID, ScheduledTask> villagerTasks = new ConcurrentHashMap<>();
     private final Map<UUID, Long> villagerTaskIntervals = new ConcurrentHashMap<>();
     private final Set<String> exemptNames;
@@ -146,6 +69,8 @@ public class LobotomizeStorage {
     private final boolean checkRoof;
     private final boolean silentLobotomizedVillagers;
     private final boolean persistLobotomizedState;
+    private final boolean ignoreStuckInDoors;
+    private final VillagerActivityPolicy activityPolicy;
     private Sound restockSound;
     private Sound levelUpSound;
     private final Logger logger;
@@ -161,10 +86,13 @@ public class LobotomizeStorage {
     public LobotomizeStorage(VillagerLobotomizer plugin) {
         this.plugin = plugin;
         this.logger = plugin.getLogger();
-        this.checkInterval = plugin.getConfig().getLong("check-interval");
-        this.inactiveCheckInterval = plugin.getConfig().getLong("inactive-check-interval", this.checkInterval);
-        this.restockInterval = plugin.getConfig().getLong("restock-interval");
-        this.restockRandomRange = plugin.getConfig().getLong("restock-random-range");
+        // check-interval/inactive-check-interval are scheduler periods (ticks) and must be >= 1, or
+        // runAtFixedRate throws IllegalArgumentException for every tracked villager. restock-interval
+        // and restock-random-range are wall-clock milliseconds and must not be negative.
+        this.checkInterval = validateInterval("check-interval", plugin.getConfig().getLong("check-interval"), 1L, 150L);
+        this.inactiveCheckInterval = validateInterval("inactive-check-interval", plugin.getConfig().getLong("inactive-check-interval", this.checkInterval), 1L, 150L);
+        this.restockInterval = validateInterval("restock-interval", plugin.getConfig().getLong("restock-interval"), 0L, 540000L);
+        this.restockRandomRange = validateInterval("restock-random-range", plugin.getConfig().getLong("restock-random-range"), 0L, 0L);
         this.onlyProfessions = plugin.getConfig().getBoolean("only-lobotomize-villagers-with-professions");
         this.onlyWithExperience = plugin.getConfig().getBoolean("only-lobotomize-villagers-with-experience");
         this.lobotomizePassengers = plugin.getConfig().getBoolean("always-lobotomize-villagers-in-vehicles");
@@ -174,7 +102,6 @@ public class LobotomizeStorage {
         String soundName = plugin.getConfig().getString("restock-sound", "");
         String levelUpSoundName = plugin.getConfig().getString("level-up-sound", "");
 
-        // Convert legacy sound names if needed
         soundName = convertLegacySoundName(soundName, "restock-sound");
         levelUpSoundName = convertLegacySoundName(levelUpSoundName, "level-up-sound");
 
@@ -185,7 +112,7 @@ public class LobotomizeStorage {
             levelUpSoundName = "";
         }
 
-        // If either sound starts with "minecraft:" we can remove that part as we handle it
+        // We add the minecraft: namespace ourselves when resolving, so strip it here
         if (!soundName.isEmpty() && soundName.startsWith("minecraft:")) {
             soundName = soundName.replace("minecraft:", "");
         }
@@ -199,12 +126,20 @@ public class LobotomizeStorage {
                 .map(String::toLowerCase)
                 .collect(Collectors.toSet());
 
-        // Empty our door set if the config is set to false
-        if (!plugin.getConfig().getBoolean("ignore-villagers-stuck-in-doors")) {
-            DOOR_BLOCKS.clear();
-        }
+        // Whether door blocks should count as a bypass (passable) block. Stored per-instance so it
+        // is re-read on /lobotomy reload, then passed into the activity policy below.
+        this.ignoreStuckInDoors = plugin.getConfig().getBoolean("ignore-villagers-stuck-in-doors");
 
-        // Get the registry
+        this.activityPolicy = new VillagerActivityPolicy(
+                this.lobotomizePassengers,
+                this.onlyProfessions,
+                this.onlyWithExperience,
+                this.checkRoof,
+                this.ignoreStuckInDoors,
+                plugin.getConfig().getBoolean("ignore-non-solid-blocks"),
+                this.exemptNames,
+                BlockClassifier.fromServerRegistry());
+
         Registry<@NotNull Sound> soundRegistry = RegistryAccess.registryAccess().getRegistry(RegistryKey.SOUND_EVENT);
 
         try {
@@ -225,7 +160,6 @@ public class LobotomizeStorage {
         try {
             if (!levelUpSoundName.isEmpty()) {
                 NamespacedKey key = new NamespacedKey(NamespacedKey.MINECRAFT, levelUpSoundName);
-                // If the sound is not found, it will throw an exception
                 this.levelUpSound = soundRegistry.getOrThrow(key);
             } else {
                 this.levelUpSound = null;
@@ -239,7 +173,10 @@ public class LobotomizeStorage {
 
         this.key = new NamespacedKey(plugin, "lastRestock");
         this.lobotomizedKey = new NamespacedKey(plugin, "isLobotomized");
-        // Use Paper's GlobalRegionScheduler for chunk processing (doesn't access entities directly)
+        this.lastRestockCheckDayTimeKey = new NamespacedKey(plugin, "lastRestockCheckDayTime");
+        // Use Paper's GlobalRegionScheduler for chunk processing. It never touches entities directly;
+        // per-chunk entity access is dispatched to the owning region via getRegionScheduler() (see
+        // scheduleChunkVillagerProcessing), keeping this Folia thread-ownership safe.
         this.chunkProcessingTask = Bukkit.getGlobalRegionScheduler().runAtFixedRate(
                 plugin,
                 SentryTaskWrapper.wrap((task) -> this.processChunks()),
@@ -287,12 +224,10 @@ public class LobotomizeStorage {
     }
 
     public final void addVillager(@NotNull Villager villager) {
-        // Don't add villagers if shutting down
         if (this.shuttingDown || !this.plugin.isEnabled()) {
             return;
         }
 
-        // Check if this villager was previously lobotomized
         boolean wasLobotomized = false;
         if (this.persistLobotomizedState) {
             PersistentDataContainer pdc = villager.getPersistentDataContainer();
@@ -318,22 +253,21 @@ public class LobotomizeStorage {
             }
         }
 
-        // Schedule per-villager task with appropriate interval
         long interval = wasLobotomized ? this.inactiveCheckInterval : this.checkInterval;
         this.scheduleVillagerTask(villager, interval);
     }
 
     public final void removeVillager(@NotNull Villager villager) {
-        // Cancel the per-villager task
-        ScheduledTask task = this.villagerTasks.remove(villager.getUniqueId());
-        this.villagerTaskIntervals.remove(villager.getUniqueId());
-        if (task != null && !task.isCancelled()) {
-            task.cancel();
-        }
-
         boolean wasInactive;
         boolean wasActive;
+        // Cancel the per-villager task and drop set membership atomically (paired with
+        // scheduleVillagerTask) so a concurrent (re)schedule can't leave a live orphan task.
         synchronized (this.stateLock) {
+            ScheduledTask task = this.villagerTasks.remove(villager.getUniqueId());
+            this.villagerTaskIntervals.remove(villager.getUniqueId());
+            if (task != null && !task.isCancelled()) {
+                task.cancel();
+            }
             wasActive = this.activeVillagers.remove(villager);
             wasInactive = this.inactiveVillagers.remove(villager);
         }
@@ -365,25 +299,38 @@ public class LobotomizeStorage {
      * @param villager The villager to clear the marker from
      */
     public void clearLobotomizedMarker(@NotNull Villager villager) {
-        if (this.persistLobotomizedState) {
-            PersistentDataContainer pdc = villager.getPersistentDataContainer();
-            if (pdc.has(this.lobotomizedKey, PersistentDataType.BYTE)) {
-                pdc.remove(this.lobotomizedKey);
-                if (this.plugin.isDebugging()) {
-                    this.logger.info("[Debug] Removed persistent lobotomized marker from " + villager.getUniqueId());
-                }
+        // Clear unconditionally, even when persist-lobotomized-state is off: a marker written under a
+        // previously-enabled config must not survive to re-lobotomize a woken villager if the feature
+        // is toggled back on. has() keeps this cheap when there is nothing to remove.
+        PersistentDataContainer pdc = villager.getPersistentDataContainer();
+        if (pdc.has(this.lobotomizedKey, PersistentDataType.BYTE)) {
+            pdc.remove(this.lobotomizedKey);
+            if (this.plugin.isDebugging()) {
+                this.logger.info("[Debug] Removed persistent lobotomized marker from " + villager.getUniqueId());
             }
         }
     }
 
     /**
-     * Flushes all villagers from storage and stops their tasks. Attempts to un-lobotomize them if possible.
+     * Flushes all villagers from storage and stops their tasks, attempting to un-lobotomize them.
+     * Equivalent to {@code flush(false)} (a true shutdown).
      */
     public final void flush() {
-        // Set shutdown flag to prevent new tasks from being scheduled
+        flush(false);
+    }
+
+    /**
+     * Flushes all villagers from storage and stops their tasks, attempting to un-lobotomize them.
+     *
+     * @param reloading {@code true} when the plugin stays enabled (a {@code /lobotomy reload}). In that
+     *                  case wake work is dispatched via each villager's EntityScheduler, which reliably
+     *                  runs for cross-region (Folia) entities. On a true shutdown ({@code false}) the
+     *                  scheduler may not run, so we mutate directly and rely on the persistent marker.
+     */
+    public final void flush(boolean reloading) {
+        // Prevent new tasks from being scheduled past this point
         this.shuttingDown = true;
-        
-        // Cancel all per-villager tasks
+
         for (ScheduledTask task : this.villagerTasks.values()) {
             if (task != null && !task.isCancelled()) {
                 task.cancel();
@@ -399,8 +346,7 @@ public class LobotomizeStorage {
             this.watchdogTask.cancel();
         }
 
-        // We'll flush all the villagers before shutdown, so if the plugin is removed, they won't have lobotomized villagers forever
-        // During shutdown, we need to handle this carefully since we can't schedule new tasks.
+        // Wake all villagers before shutdown so they aren't left lobotomized forever if the plugin is removed
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
         List<Villager> toFlush;
         synchronized (this.stateLock) {
@@ -412,39 +358,38 @@ public class LobotomizeStorage {
             this.inactiveVillagers.clear();
             this.activeVillagers.clear();
         }
-        
+
+        // On a true shutdown the scheduler may not run, so cross-region (Folia) villagers can't be
+        // reliably woken; warn once. The persistent marker (when enabled) re-tracks them on next
+        // load so the normal check loop can wake them once their chunk is active again.
+        if (!reloading && this.plugin.isFolia() && !toFlush.isEmpty()) {
+            this.logger.info("Some Villagers may remain lobotomized after shutdown until their chunk next loads. "
+                    + "Enable persist-lobotomized-state so they are re-evaluated and woken once their chunk reloads.");
+        }
+
         for (Villager villager : toFlush) {
             if (this.plugin.isDebugging()) {
                 this.logger.info("Un-lobotomizing Villager " + villager.getUniqueId());
             }
 
-            if (plugin.isFolia()) {
-                this.logger.info("Some Villagers may remain lobotomized after shutdown. If you remove the plugin they will be lobotomized forever.");
-            }
-            
-            try {
-                // During shutdown, try setting directly first since scheduler might not work
-                villager.setAware(true);
-                if (this.silentLobotomizedVillagers) {
-                    villager.setSilent(false);
-                }
-                // Remove persistent lobotomized marker
-                if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().remove(this.lobotomizedKey);
-                }
-            } catch (IllegalStateException e) {
-                // If we get a thread violation, try using entity scheduler as last resort
+            if (reloading) {
+                // Plugin stays enabled: the entity scheduler will run, so this works cross-region
+                // without throwing a thread-ownership exception per villager.
                 try {
-                    villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> {
-                        villager.setAware(true);
-                        if (this.silentLobotomizedVillagers) {
-                            villager.setSilent(false);
-                        }
-                        // Remove persistent lobotomized marker
-                        if (this.persistLobotomizedState) {
-                            villager.getPersistentDataContainer().remove(this.lobotomizedKey);
-                        }
-                    }), null);
+                    villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> wakeVillager(villager)), null);
+                } catch (Exception e) {
+                    this.logger.log(java.util.logging.Level.WARNING, "Failed to schedule un-lobotomize for villager " + villager.getUniqueId() + " during reload: " + e.getMessage(), e);
+                }
+                continue;
+            }
+
+            try {
+                // During shutdown, try setting directly first since the scheduler might not run.
+                wakeVillager(villager);
+            } catch (IllegalStateException e) {
+                // If we get a thread violation, try using the entity scheduler as a last resort.
+                try {
+                    villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> wakeVillager(villager)), null);
                 } catch (Exception schedulerException) {
                     // If both fail, log warning but don't crash the shutdown
                     this.logger.log(java.util.logging.Level.WARNING, "Failed to un-lobotomize villager " + villager.getUniqueId() + " during shutdown: " + e.getMessage(), e);
@@ -454,12 +399,30 @@ public class LobotomizeStorage {
             }
         }
     }
+
+    /**
+     * Restores a villager to its un-lobotomized vanilla state. Must be called on the thread/region
+     * that owns the entity (call directly only when already on it, otherwise via its EntityScheduler).
+     */
+    private void wakeVillager(@NotNull Villager villager) {
+        villager.setAware(true);
+        if (this.silentLobotomizedVillagers) {
+            villager.setSilent(false);
+        }
+        clearLobotomizedMarker(villager);
+    }
     
     
     /**
      * Thread-safe wrapper for processing villagers using entity scheduling
      */
     private void processVillagerSafely(@NotNull Villager villager) {
+        // After flush()/reload swap, an old storage instance can still have in-flight callbacks on
+        // other region threads. Bail out promptly so we don't mutate the old, orphaned sets or
+        // reschedule tasks via the dead instance while the new instance is taking over.
+        if (this.shuttingDown) {
+            return;
+        }
         try {
             if (!villager.isValid() || villager.isDead()) {
                 ScheduledTask task = this.villagerTasks.remove(villager.getUniqueId());
@@ -506,18 +469,21 @@ public class LobotomizeStorage {
 
     private boolean processVillager(@NotNull Villager villager, boolean active) {
         if (!villager.isValid() || villager.isDead()) {
-            // Remove from whatever
             return true;
         }
 
         Location villagerLocation = villager.getLocation().add(0.0F, 0.51, 0.0F);
+        int blockX = villagerLocation.getBlockX();
+        int blockY = villagerLocation.getBlockY();
+        int blockZ = villagerLocation.getBlockZ();
 
-        // If the chunk is not loaded, and the villager is not active, we want to add them to the active list
-        if (!villager.getWorld().isChunkLoaded(villagerLocation.getBlockX() >> 4, villagerLocation.getBlockZ() >> 4)) {
+        // Chunk unloaded: can't evaluate blocks, keep current state
+        if (!villager.getWorld().isChunkLoaded(blockX >> 4, blockZ >> 4)) {
             return false; // Keep current if chunk is unloaded
         }
 
-        boolean shouldBeActive = this.shouldBeActive(villager);
+        // Reuse the coordinates already computed above instead of cloning the location again.
+        boolean shouldBeActive = this.shouldBeActive(villager, blockX, blockY, blockZ);
 
         if (shouldBeActive) {
             if (!active) {
@@ -526,13 +492,7 @@ public class LobotomizeStorage {
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(false);
                 }
-                // Remove persistent lobotomized marker
-                if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().remove(this.lobotomizedKey);
-                    if (this.plugin.isDebugging()) {
-                        this.logger.info("[Debug] Removed persistent lobotomized marker from " + villager.getUniqueId());
-                    }
-                }
+                clearLobotomizedMarker(villager);
                 setActive(villager);
                 if (this.plugin.isDebugging()) {
                     this.logger.info("[Debug] Villager " + villager + " (" + villager.getUniqueId() + ") is now active");
@@ -544,7 +504,7 @@ public class LobotomizeStorage {
                 villager.setGlowing(true);
             }
         } else {
-            // Refresh any trades as this villager is inactive
+            // Inactive villagers still need their trades refreshed
             this.refreshTrades(villager);
 
             if (active) {
@@ -553,7 +513,6 @@ public class LobotomizeStorage {
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(true);
                 }
-                // Set persistent lobotomized marker
                 if (this.persistLobotomizedState) {
                     villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
                     if (this.plugin.isDebugging()) {
@@ -632,38 +591,36 @@ public class LobotomizeStorage {
     }
 
     private boolean shouldRestock(@NotNull Villager villager) {
-        NamespacedKey lastRestockGameTimeKey = new NamespacedKey(this.plugin, "lastRestockGameTime");
-        NamespacedKey lastRestockCheckDayTimeKey = new NamespacedKey(this.plugin, "lastRestockCheckDayTime");
-        
-        boolean result = VillagerUtils.shouldRestock(villager, lastRestockGameTimeKey, lastRestockCheckDayTimeKey);
-        
-        // if (this.plugin.isDebugging() && !result) {
-        //     // Log why shouldRestock returned false
-        //     long fullTime = villager.getWorld().getFullTime();
-        //     long lastRestockFullTime = villager.getPersistentDataContainer().getOrDefault(lastRestockGameTimeKey, PersistentDataType.LONG, 0L);
-        //     int restocksToday = villager.getRestocksToday();
-        //     boolean cooldownPassed = fullTime > lastRestockFullTime + 2400L;
-        //     boolean needsRestock = VillagerUtils.needsToRestock(villager);
-            
-        //     this.logger.info("[Debug] shouldRestock=false for " + villager.getUniqueId() + 
-        //             ": restocksToday=" + restocksToday + " (need !=2)" +
-        //             ", fullTime=" + fullTime + ", lastRestockFullTime=" + lastRestockFullTime +
-        //             ", cooldownPassed=" + cooldownPassed + " (need >2400 ticks)" +
-        //             ", needsToRestock=" + needsRestock);
-        // }
-        
-        return result;
+        return VillagerUtils.shouldRestock(villager, this.lastRestockCheckDayTimeKey);
     }
 
     private void refreshTrades(@NotNull Villager villager) {
+        PersistentDataContainer pdc = villager.getPersistentDataContainer();
+        long lastRestock = pdc.getOrDefault(this.key, PersistentDataType.LONG, 0L);
+
+        long now = System.currentTimeMillis();
+        long timeSinceLastRestock = now - lastRestock;
+        long effectiveInterval = this.restockInterval - (this.restockRandomRange > 0 ? this.random.nextLong(this.restockRandomRange) : 0);
+        boolean intervalPassed = timeSinceLastRestock > effectiveInterval;
+
+        int currentLevel = villager.getVillagerLevel();
+        int expectedLevel = VillagerUtils.getVillagerLevel(villager);
+        boolean needsLevelUp = currentLevel < expectedLevel;
+
+        // Cheap gate first: if neither a restock nor a level-up could happen this tick, skip the
+        // daytime check and the 27-block job-site scan entirely. restock-interval is much larger
+        // than check-interval, so the interval gate is false on most checks for most villagers.
+        if (!intervalPassed && !needsLevelUp) {
+            return;
+        }
+
+        // Both restocking and leveling require it to be day (in the overworld) with a job site nearby.
         if (villager.getWorld().getEnvironment() == World.Environment.NORMAL && !villager.getWorld().isDayTime()) {
-            // It's night, do not refresh trades
             if (this.plugin.isDebugging()) {
                 this.logger.info("[Debug] Skipping trade refresh for " + villager.getUniqueId() + " - it's night time in overworld");
             }
             return;
         }
-
 
         if (!VillagerUtils.isJobSiteNearby(villager)) {
             if (this.plugin.isDebugging()) {
@@ -672,19 +629,12 @@ public class LobotomizeStorage {
             return;
         }
 
-        PersistentDataContainer pdc = villager.getPersistentDataContainer();
-        long lastRestock = pdc.getOrDefault(this.key, PersistentDataType.LONG, 0L);
-
-        long now = System.currentTimeMillis();
-        long timeSinceLastRestock = now - lastRestock;
-        long effectiveInterval = this.restockInterval - (this.restockRandomRange > 0 ? this.random.nextLong(this.restockRandomRange) : 0);
-        
         if (this.plugin.isDebugging()) {
-            this.logger.info("[Debug] Trade refresh check for " + villager.getUniqueId() + 
+            this.logger.info("[Debug] Trade refresh check for " + villager.getUniqueId() +
                     ": timeSinceLastRestock=" + timeSinceLastRestock + "ms, effectiveInterval=" + effectiveInterval + "ms, restocksToday=" + villager.getRestocksToday());
         }
-        
-        if (timeSinceLastRestock > effectiveInterval && shouldRestock(villager)) {
+
+        if (intervalPassed && shouldRestock(villager)) {
             lastRestock = now;
             pdc.set(this.key, PersistentDataType.LONG, lastRestock);
             List<MerchantRecipe> recipes = new ArrayList<>(villager.getRecipes());
@@ -710,26 +660,14 @@ public class LobotomizeStorage {
                         1.0F);
             }
         } else if (this.plugin.isDebugging()) {
-            boolean intervalPassed = timeSinceLastRestock > effectiveInterval;
-            this.logger.info("[Debug] Trade refresh NOT performed for " + villager.getUniqueId() + 
+            this.logger.info("[Debug] Trade refresh NOT performed for " + villager.getUniqueId() +
                     ": intervalPassed=" + intervalPassed + " (needed " + effectiveInterval + "ms, had " + timeSinceLastRestock + "ms)" +
                     (intervalPassed ? ", shouldRestock=false" : ""));
         }
 
-        // Derek comment - Not sure if we want to split this level up check, to separate it from refresh trades. Might
-        // be better to(?)
-        // Lets also see if we need to level up the villager
-        int currentLevel = villager.getVillagerLevel();
-
-        // If we're max level, then just return early
-        if (currentLevel == 5) {
-            return;
-        }
-
-        int expectedLevel = VillagerUtils.getVillagerLevel(villager);
-
-        if (currentLevel < expectedLevel) {
-            // We can just set the villager level to the expected level
+        // Level the villager up to match its accumulated experience. Gated on day + job site above
+        // (mirrors restock); max villager level is 5, which getVillagerLevel already caps.
+        if (needsLevelUp) {
             int increaseAmount = Math.max(0, expectedLevel - currentLevel);
             villager.increaseLevel(increaseAmount);
             if (this.levelUpSound != null) {
@@ -738,92 +676,22 @@ public class LobotomizeStorage {
             PotionEffect regenEffect = new PotionEffect(PotionEffectType.REGENERATION, 200, 0, false);
             villager.addPotionEffect(regenEffect);
 
-            // Write a log message if we're debugging
             if (this.plugin.isDebugging()) {
                 this.plugin.getLogger().info("Villager " + villager.getUniqueId() + " was leveled up to level " + expectedLevel + " from level " + currentLevel);
             }
         }
     }
 
-    private boolean canMoveThrough(World w, int x, int y, int z, boolean roof) {
-        boolean isChunkLoaded = w.isChunkLoaded(x >> 4, z >> 4);
-        if (!isChunkLoaded) {
-            return false;
-        }
-        Block blockAtHead = w.getBlockAt(x, y + 1, z);
-        Block blockAtFeet = w.getBlockAt(x, y, z);
-        Block blockUnderFeet = w.getBlockAt(x, y - 1, z);
-
-        // First check if the block at the head is solid, if so, then we can't move from here
-        boolean isHeadImpassable = this.testImpassable(IMPASSABLE_REGULAR_FLOOR, blockAtHead, false);
-        // Next check if the block at the feet is just regular (villagers can walk on carpets)
-        boolean isFeetImpassable = this.testImpassable(IMPASSABLE_REGULAR, blockAtFeet, false);
-        // Next check if the block under the feet is regular or tall
-        boolean isUnderFeetImpassable = this.testImpassable(IMPASSABLE_TALL, blockUnderFeet, true);
-        return !isHeadImpassable && !isFeetImpassable && (!roof || !isUnderFeetImpassable);
-    }
-
-    /**
-     * Tests if a block is impassable, based on the set provided.
-     * If onlyTallBlocks is true, it will only check for tall blocks.
-     * If false, it will check for all blocks in the set.
-     *
-     * @param set            The set of materials to check against
-     * @param b              The block to test
-     * @param onlyTallBlocks If true, only checks tall blocks
-     * @return true if the block is impassable, false otherwise
-     */
-    private boolean testImpassable(@NotNull EnumSet<Material> set, @NotNull Block b, boolean onlyTallBlocks) {
-        Material type = b.getType();
-
-        // Skip any extra checks here
-        if (set.contains(type)) {
-            return true;
-        }
-
-        // If we're only checking tall blocks and we reach this part, return false early
-        if (onlyTallBlocks) {
-            return false;
-        }
-
-        boolean isCarpet = type.name().contains("_CARPET");
-        boolean isBed = type.name().contains("_BED");
-        boolean isWater = type == Material.WATER;
-        BlockData blockData = b.getBlockData();
-        boolean isCrop = blockData instanceof Ageable;
-        boolean isABypassBlock = (isCrop || isBed || isCarpet || DOOR_BLOCKS.contains(type));
-        boolean isNonSolid = !type.isSolid() && this.plugin.getConfig().getBoolean("ignore-non-solid-blocks") && !PROFESSION_BLOCKS.contains(type);
-        // A block is impassable if:
-        // 1. It isn't water and it's not passable
-        // 2. AND it's not a bypass block (the early return ensures if it's in our testing set, it's impassable)
-        // 3. AND it's in the set
-        return (!isWater && !b.isPassable() && !isABypassBlock && !isNonSolid) || set.contains(type);
-    }
-
-    private boolean canMoveCardinally(World w, int x, int y, int z, boolean roof) {
-        // Essentially check x + 1, x - 1, z + 1, z - 1, and return the or of the results
-        // Means as long as there's 1 walkable path it should not be lobotomized
-        Boolean xPlusOne = this.canMoveThrough(w, x + 1, y, z, roof);
-        Boolean xMinusOne = this.canMoveThrough(w, x - 1, y, z, roof);
-        Boolean zPlusOne = this.canMoveThrough(w, x, y, z + 1, roof);
-        Boolean zMinusOne = this.canMoveThrough(w, x, y, z - 1, roof);
-
-        return xPlusOne || xMinusOne || zPlusOne || zMinusOne;
-    }
-
-
     public void handleBlockChange(Block block) {
         if (this.plugin.isDisableChunkVillagerUpdate()) {
             return;
         }
-        // Create a list of chunks we'll add to
-        List<Chunk> chunksToProcess = new ArrayList<>();
-        // Get our chunk
+        // Mark the block's own chunk, plus any edge-adjacent neighbor, without allocating a list
+        // per event (block break/place fires constantly on a busy server).
         Chunk chunk = block.getChunk();
-        // Put our chunk in the list
-        chunksToProcess.add(chunk);
+        long stamp = System.currentTimeMillis();
+        changedChunks.put(chunk, stamp);
 
-        // We also want to do neighbors if needed
         int blockInChunkX = block.getX() & 0xF;
         int blockInChunkZ = block.getZ() & 0xF;
 
@@ -831,19 +699,16 @@ public class LobotomizeStorage {
 
         // If <= 1 or >= 14 then add the -/+ chunk respectively without loading them
         if (blockInChunkX <= 1 && world.isChunkLoaded(chunk.getX() - 1, chunk.getZ())) {
-            chunksToProcess.add(world.getChunkAt(chunk.getX() - 1, chunk.getZ()));
+            changedChunks.put(world.getChunkAt(chunk.getX() - 1, chunk.getZ()), stamp);
         } else if (blockInChunkX >= 14 && world.isChunkLoaded(chunk.getX() + 1, chunk.getZ())) {
-            chunksToProcess.add(world.getChunkAt(chunk.getX() + 1, chunk.getZ()));
+            changedChunks.put(world.getChunkAt(chunk.getX() + 1, chunk.getZ()), stamp);
         }
 
         // Same for Z
         if (blockInChunkZ <= 1 && world.isChunkLoaded(chunk.getX(), chunk.getZ() - 1)) {
-            chunksToProcess.add(world.getChunkAt(chunk.getX(), chunk.getZ() - 1));
+            changedChunks.put(world.getChunkAt(chunk.getX(), chunk.getZ() - 1), stamp);
         } else if (blockInChunkZ >= 14 && world.isChunkLoaded(chunk.getX(), chunk.getZ() + 1)) {
-            chunksToProcess.add(world.getChunkAt(chunk.getX(), chunk.getZ() + 1));
-        }
-        for (Chunk c : chunksToProcess) {
-            changedChunks.put(c, System.currentTimeMillis());
+            changedChunks.put(world.getChunkAt(chunk.getX(), chunk.getZ() + 1), stamp);
         }
     }
 
@@ -853,61 +718,69 @@ public class LobotomizeStorage {
             Chunk chunk = entry.getKey();
             long lastChange = entry.getValue();
 
-            // If the chunk hasn't changed in a while, remove it
+            // Drop chunks idle past the update threshold (3 seconds)
             if (now - lastChange > 3000) {
                 return true;
             }
 
-            // Are we unloaded?
             if (!chunk.isLoaded()) {
                 return true;
             }
 
-            // Log a debug
             if (this.plugin.isChunkDebugging()) {
                 this.logger.info("[Debug] Processing chunk " + chunk.getX() + ", " + chunk.getZ() + " for villagers");
             }
 
-            // Schedule villager processing for this chunk on the appropriate region
             if (chunk.isLoaded()) {
                 this.scheduleChunkVillagerProcessing(chunk);
             }
 
-            // Keep tracked
             return false;
         });
     }
     
     /**
-     * Schedules villager processing for a chunk using region-appropriate scheduling
+     * Schedules villager processing for a chunk using region-appropriate scheduling.
+     *
+     * <p>Entity enumeration ({@link Chunk#getEntities()}) and per-entity access must happen on the
+     * region thread that owns the chunk. This method is invoked from {@link #processChunks()} on the
+     * global region scheduler, which on Folia does <strong>not</strong> own arbitrary chunks, so
+     * touching entities here directly would throw a thread-ownership violation. We therefore dispatch
+     * the whole body onto the owning region via {@link io.papermc.paper.threadedregions.scheduler.RegionScheduler}
+     * (which simply runs on the main thread on non-Folia Paper).
      */
     private void scheduleChunkVillagerProcessing(Chunk chunk) {
         if (!chunk.isLoaded()) {
             return;
         }
 
-        Entity[] entities = chunk.getEntities();
-        for (Entity entity : entities) {
-            if (entity instanceof Villager villager) {
-                // Check if this villager is tracked by us
-                if (inactiveVillagers.contains(villager) || activeVillagers.contains(villager)) {
-                    // Schedule processing on the villager's region thread using Paper's EntityScheduler
-                    try {
-                        villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((scheduledTask) -> {
+        final World world = chunk.getWorld();
+        final int cx = chunk.getX();
+        final int cz = chunk.getZ();
+
+        try {
+            Bukkit.getRegionScheduler().run(this.plugin, world, cx, cz, SentryTaskWrapper.wrap((scheduledTask) -> {
+                // Re-check liveness: the region task runs a tick or more after we were scheduled.
+                if (!chunk.isLoaded()) {
+                    return;
+                }
+                for (Entity entity : chunk.getEntities()) {
+                    if (entity instanceof Villager villager) {
+                        if (this.inactiveVillagers.contains(villager) || this.activeVillagers.contains(villager)) {
                             boolean isActive = this.activeVillagers.contains(villager);
                             if (this.processVillager(villager, isActive)) {
                                 if (this.plugin.isDebugging()) {
-                                    this.logger.info("[Debug] Processed villager " + villager + " (" + villager.getUniqueId() + ") in chunk " + chunk.getX() + ", " + chunk.getZ());
+                                    this.logger.info("[Debug] Processed villager " + villager + " (" + villager.getUniqueId() + ") in chunk " + cx + ", " + cz);
                                 }
                             }
-                        }), null);
-                    } catch (IllegalPluginAccessException e) {
-                        // Plugin disabled, ignore
-                        if (this.plugin.isDebugging()) {
-                            this.logger.fine("Skipped chunk villager processing; plugin disabled or stopping.");
                         }
                     }
                 }
+            }));
+        } catch (IllegalPluginAccessException e) {
+            // Plugin disabled, ignore
+            if (this.plugin.isDebugging()) {
+                this.logger.fine("Skipped chunk villager processing; plugin disabled or stopping.");
             }
         }
     }
@@ -920,64 +793,72 @@ public class LobotomizeStorage {
      * @return true if the villager should be active, false otherwise.
      */
     private boolean shouldBeActive(Villager villager) {
-        Location villagerLoc = villager.getLocation().add(0.0F, 0.51, 0.0F);
+        Location loc = villager.getLocation().add(0.0F, 0.51, 0.0F);
+        return shouldBeActive(villager, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
 
-        // Check name
+    private boolean shouldBeActive(Villager villager, int blockX, int blockY, int blockZ) {
+        return this.activityPolicy.shouldBeActive(
+                villagerStateOf(villager, blockX, blockY, blockZ),
+                gridOf(villager.getWorld()));
+    }
+
+    private VillagerState villagerStateOf(Villager villager, int blockX, int blockY, int blockZ) {
         Component customName = villager.customName();
-        String villagerName = customName == null ? "" : PlainTextComponentSerializer.plainText().serialize(customName).toLowerCase();
+        String name = customName == null
+                ? ""
+                : PlainTextComponentSerializer.plainText().serialize(customName).toLowerCase();
+        return new VillagerState(
+                name,
+                villager.isSwimming(),
+                villager.isSleeping(),
+                villager.getVehicle() instanceof Vehicle,
+                villager.getProfession() == Villager.Profession.NONE,
+                villager.getVillagerExperience(),
+                blockX, blockY, blockZ);
+    }
 
-        if (villagerName.contains("nobrain")) {
-            return false;
-        } else if (exemptNames.contains(villagerName)) {
-            return true;
-        }
+    /**
+     * Adapts a live {@link World} to a {@link BlockGrid}. Returns {@code null} for coordinates in an
+     * unloaded chunk, which the policy treats as "cannot move there" — this reproduces the original
+     * per-column {@code isChunkLoaded} short-circuit for cardinal neighbours. The villager's own
+     * column (feet/head/floor/roof) is assumed loaded by callers ({@code processVillager} guards the
+     * villager's chunk before evaluating; {@code reconcile} only runs on valid in-world villagers),
+     * so the policy's null-tolerance for the centre column is never exercised in practice. A future
+     * caller that evaluates a villager whose own chunk may be unloaded must revisit that assumption.
+     * <p>
+     * A single {@code shouldBeActive} evaluation queries up to ~16 blocks, the bulk of them in the
+     * villager's own chunk (only cardinal neighbours near a chunk edge cross into another chunk). The
+     * adapter caches the most-recently-resolved {@link Chunk} so those queries collapse to one
+     * chunk-map lookup instead of one per block. The returned grid is stateful and not thread-safe,
+     * but each evaluation builds a fresh one and drives it synchronously on the owning region thread,
+     * where the cached chunk cannot unload mid-evaluation.
+     */
+    private static BlockGrid gridOf(World world) {
+        return new BlockGrid() {
+            private Chunk cachedChunk;
+            private int cachedChunkX;
+            private int cachedChunkZ;
 
-        // Villagers who are lobotomized will just sink
-
-        // Are we currently swimming?
-        if (villager.isSwimming()) {
-            return true; // Let them keep swimming
-        }
-
-        // Is our feet in water? (No idea if #isSwimming() works when lobotomized)
-        Block feetBlock = villager.getWorld().getBlockAt(villagerLoc.getBlockX(), villagerLoc.getBlockY(), villagerLoc.getBlockZ());
-        Block headBlock = villager.getWorld().getBlockAt(villagerLoc.getBlockX(), villagerLoc.getBlockY() + 1, villagerLoc.getBlockZ());
-        if (feetBlock.getType() == Material.WATER || headBlock.getType() == Material.WATER) {
-            // If the feet or head block is water, we can consider the villager active
-            return true;
-        }
-
-        // Is the villager currently sleeping? (A sleeping villager doesn't do anything really anyways)
-        if (villager.isSleeping()) {
-            return true;
-        }
-
-        // Check vehicle
-        if (this.lobotomizePassengers && villager.getVehicle() instanceof Vehicle) {
-            return false;
-        }
-
-        // Check profession
-        if (this.onlyProfessions && villager.getProfession() == Villager.Profession.NONE) {
-            return true;
-        }
-
-        // Check experience
-        if (this.onlyWithExperience && villager.getVillagerExperience() == 0) {
-            return true;
-        }
-
-        // Check movement
-        Material floorBlockMaterial = villager.getWorld().getBlockAt(villagerLoc.getBlockX(), villagerLoc.getBlockY() - 1, villagerLoc.getBlockZ()).getType();
-        Block villagerRoof = villager.getWorld().getBlockAt(villagerLoc.getBlockX(), villagerLoc.getBlockY() + 2, villagerLoc.getBlockZ());
-
-        if (this.checkRoof && villagerRoof.getType() == Material.AIR) {
-            return true;
-        }
-
-        boolean hasRoof = floorBlockMaterial == Material.HONEY_BLOCK || this.testImpassable(IMPASSABLE_ALL, villagerRoof, false);
-
-        return this.canMoveCardinally(villager.getWorld(), villagerLoc.getBlockX(), villagerLoc.getBlockY(), villagerLoc.getBlockZ(), hasRoof);
+            @Override
+            public BlockSnapshot at(int x, int y, int z) {
+                int chunkX = x >> 4;
+                int chunkZ = z >> 4;
+                Chunk chunk = this.cachedChunk;
+                if (chunk == null || chunkX != this.cachedChunkX || chunkZ != this.cachedChunkZ) {
+                    if (!world.isChunkLoaded(chunkX, chunkZ)) {
+                        return null;
+                    }
+                    chunk = world.getChunkAt(chunkX, chunkZ);
+                    this.cachedChunk = chunk;
+                    this.cachedChunkX = chunkX;
+                    this.cachedChunkZ = chunkZ;
+                }
+                Block b = chunk.getBlock(x & 0xF, y, z & 0xF);
+                Material type = b.getType();
+                return new BlockSnapshot(type, b.isPassable(), type.isSolid());
+            }
+        };
     }
 
     private String convertLegacySoundName(String soundName, String configKey) {
@@ -994,6 +875,24 @@ public class LobotomizeStorage {
     }
 
     /**
+     * Validates a config interval, clamping out-of-range values to a safe fallback and warning.
+     *
+     * @param configKey the config key (for the warning message)
+     * @param value     the configured value
+     * @param min       the minimum acceptable value (inclusive)
+     * @param fallback  the value to use when {@code value < min}
+     * @return {@code value} if it is at least {@code min}, otherwise {@code fallback}
+     */
+    private long validateInterval(String configKey, long value, long min, long fallback) {
+        if (value < min) {
+            this.logger.warning("Config value '" + configKey + "' must be >= " + min + " (got " + value
+                    + "); falling back to " + fallback + ".");
+            return fallback;
+        }
+        return value;
+    }
+
+    /**
      * Schedule a villager with the given interval, replacing any existing task.
      */
     private void scheduleVillagerTask(@NotNull Villager villager, long interval) {
@@ -1002,24 +901,34 @@ public class LobotomizeStorage {
         }
 
         UUID id = villager.getUniqueId();
-        ScheduledTask existing = this.villagerTasks.remove(id);
-        if (existing != null && !existing.isCancelled()) {
-            existing.cancel();
-        }
+        // Manage the task and set membership atomically (paired with removeVillager) so a concurrent
+        // removal can't interleave between cancelling the old task and installing the new one, which
+        // would leak a live task for a villager that is no longer tracked.
+        synchronized (this.stateLock) {
+            // Don't install a task for a villager that was removed concurrently.
+            if (!this.activeVillagers.contains(villager) && !this.inactiveVillagers.contains(villager)) {
+                return;
+            }
 
-        try {
-            ScheduledTask task = villager.getScheduler().runAtFixedRate(
-                    this.plugin,
-                    SentryTaskWrapper.wrap((scheduledTask) -> this.processVillagerSafely(villager)),
-                    null,
-                    interval,
-                    interval
-            );
-            this.villagerTasks.put(id, task);
-            this.villagerTaskIntervals.put(id, interval);
-        } catch (IllegalPluginAccessException e) {
-            untrack(villager);
-            this.villagerTaskIntervals.remove(id);
+            ScheduledTask existing = this.villagerTasks.remove(id);
+            if (existing != null && !existing.isCancelled()) {
+                existing.cancel();
+            }
+
+            try {
+                ScheduledTask task = villager.getScheduler().runAtFixedRate(
+                        this.plugin,
+                        SentryTaskWrapper.wrap((scheduledTask) -> this.processVillagerSafely(villager)),
+                        null,
+                        interval,
+                        interval
+                );
+                this.villagerTasks.put(id, task);
+                this.villagerTaskIntervals.put(id, interval);
+            } catch (IllegalPluginAccessException e) {
+                untrack(villager);
+                this.villagerTaskIntervals.remove(id);
+            }
         }
     }
 
@@ -1033,6 +942,4 @@ public class LobotomizeStorage {
         }
         this.scheduleVillagerTask(villager, newInterval);
     }
-
-    // Removed ActivatorTask and DeactivatorTask classes - replaced with per-villager entity scheduling
 }

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -355,14 +355,6 @@ public class LobotomizeStorage {
         // Prevent new tasks from being scheduled past this point
         this.shuttingDown = true;
 
-        for (ScheduledTask task : this.villagerTasks.values()) {
-            if (task != null && !task.isCancelled()) {
-                task.cancel();
-            }
-        }
-        this.villagerTasks.clear();
-        this.villagerTaskIntervals.clear();
-
         if (this.chunkProcessingTask != null && !this.chunkProcessingTask.isCancelled()) {
             this.chunkProcessingTask.cancel();
         }
@@ -372,8 +364,18 @@ public class LobotomizeStorage {
 
         // Wake all villagers before shutdown so they aren't left lobotomized forever if the plugin is removed
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
+        // Cancel and clear per-villager tasks under the same lock that scheduleVillagerTask holds, so a
+        // concurrent schedule can't install an orphan task after we clear (it re-checks shuttingDown there).
         List<Villager> toFlush;
         synchronized (this.stateLock) {
+            for (ScheduledTask task : this.villagerTasks.values()) {
+                if (task != null && !task.isCancelled()) {
+                    task.cancel();
+                }
+            }
+            this.villagerTasks.clear();
+            this.villagerTaskIntervals.clear();
+
             toFlush = new ArrayList<>(this.inactiveVillagers.size() + this.activeVillagers.size());
             toFlush.addAll(this.inactiveVillagers);
             for (Villager v : this.activeVillagers) {
@@ -520,13 +522,15 @@ public class LobotomizeStorage {
         boolean shouldBeActive = this.shouldBeActive(villager, blockX, blockY, blockZ);
 
         if (shouldBeActive) {
+            // Clear any stale marker whenever the villager should be active, not just on transition,
+            // so a marker left by a prior persist-enabled run can't re-lobotomize it after a config flip.
+            clearLobotomizedMarker(villager);
             if (!active) {
                 // Already running on entity thread, safe to modify villager
                 villager.setAware(true);
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(false);
                 }
-                clearLobotomizedMarker(villager);
                 setActive(villager);
                 if (this.plugin.isDebugging()) {
                     this.logger.info("[Debug] Villager " + villager + " (" + villager.getUniqueId() + ") is now active");
@@ -558,6 +562,17 @@ public class LobotomizeStorage {
                     this.logger.info("[Debug] Villager " + villager + " (" + villager.getUniqueId() + ") is now inactive");
                 }
                 return true; // Transitioned: caller may want to reschedule at new interval
+            }
+            // Re-assert lobotomized state if the villager drifted back to aware while still tracked
+            // inactive (such as a stale wake callback from an old storage instance after a reload).
+            if (villager.isAware()) {
+                villager.setAware(false);
+                if (this.silentLobotomizedVillagers) {
+                    villager.setSilent(true);
+                }
+                if (this.persistLobotomizedState) {
+                    villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                }
             }
             if (this.plugin.isDebugging() && !this.plugin.isFolia() && this.plugin.getInactiveVillagersTeam() != null) {
                 this.plugin.getInactiveVillagersTeam().addEntity(villager);
@@ -654,7 +669,12 @@ public class LobotomizeStorage {
 
         long now = System.currentTimeMillis();
         long timeSinceLastRestock = now - lastRestock;
-        long effectiveInterval = this.restockInterval - (this.restockRandomRange > 0 ? this.random.nextLong(this.restockRandomRange) : 0);
+        // Bound the random offset by restockInterval so effectiveInterval can't go negative when
+        // restock-random-range is misconfigured larger than restock-interval, which would make
+        // intervalPassed always true until the daily restock cap is hit.
+        long randomBound = Math.min(this.restockRandomRange, this.restockInterval);
+        long randomOffset = randomBound > 0 ? this.random.nextLong(randomBound) : 0L;
+        long effectiveInterval = this.restockInterval - randomOffset;
         boolean intervalPassed = timeSinceLastRestock > effectiveInterval;
 
         int currentLevel = villager.getVillagerLevel();
@@ -997,6 +1017,11 @@ public class LobotomizeStorage {
         // removal can't interleave between cancelling the old task and installing the new one, which
         // would leak a live task for a villager that is no longer tracked.
         synchronized (this.stateLock) {
+            // Re-check under the lock: flush() flips shuttingDown and clears tasks here too, so this
+            // closes the window where a schedule slipping past the pre-lock check installs an orphan.
+            if (this.shuttingDown) {
+                return;
+            }
             // Don't install a task for a villager that was removed concurrently.
             if (!this.activeVillagers.contains(villager) && !this.inactiveVillagers.contains(villager)) {
                 return;

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -83,6 +83,11 @@ public class LobotomizeStorage {
     // is never observable in both sets simultaneously.
     private final Object stateLock = new Object();
 
+    /**
+     * Initializes the villager lobotomization storage system.
+     *
+     * @param plugin the VillagerLobotomizer plugin instance providing configuration
+     */
     public LobotomizeStorage(VillagerLobotomizer plugin) {
         this.plugin = plugin;
         this.logger = plugin.getLogger();
@@ -215,6 +220,12 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Removes a villager from all tracking sets.
+     *
+     * @param v the villager to remove
+     * @return {@code true} if the villager was being tracked, {@code false} otherwise
+     */
     private boolean untrack(@NotNull Villager v) {
         synchronized (this.stateLock) {
             boolean wasActive = this.activeVillagers.remove(v);
@@ -223,6 +234,14 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Registers a villager for active/inactive state tracking with periodic monitoring.
+     *
+     * If persistent lobotomized state is configured, checks whether the villager
+     * carries a lobotomized marker; if so, initializes it as inactive, otherwise
+     * as active. Schedules a periodic task to monitor and potentially transition
+     * the villager between states.
+     */
     public final void addVillager(@NotNull Villager villager) {
         if (this.shuttingDown || !this.plugin.isEnabled()) {
             return;
@@ -257,6 +276,12 @@ public class LobotomizeStorage {
         this.scheduleVillagerTask(villager, interval);
     }
 
+    /**
+     * Removes a villager from tracking and reactivates it if it was previously lobotomized.
+     *
+     * Cancels the villager's scheduled processing task and removes it from the tracking sets.
+     * If the villager was inactive, restores awareness and optionally sound.
+     */
     public final void removeVillager(@NotNull Villager villager) {
         boolean wasInactive;
         boolean wasActive;
@@ -294,9 +319,8 @@ public class LobotomizeStorage {
 
     /**
      * Clears the persistent lobotomized marker from a villager.
-     * Used by the wake command to prevent re-lobotomization on chunk reload.
      *
-     * @param villager The villager to clear the marker from
+     * @param villager the villager to clear the marker from
      */
     public void clearLobotomizedMarker(@NotNull Villager villager) {
         // Clear unconditionally, even when persist-lobotomized-state is off: a marker written under a
@@ -312,20 +336,20 @@ public class LobotomizeStorage {
     }
 
     /**
-     * Flushes all villagers from storage and stops their tasks, attempting to un-lobotomize them.
-     * Equivalent to {@code flush(false)} (a true shutdown).
+     * Flushes all tracked villagers from storage, stops their processing tasks, and attempts to un-lobotomize them during shutdown.
      */
     public final void flush() {
         flush(false);
     }
 
     /**
-     * Flushes all villagers from storage and stops their tasks, attempting to un-lobotomize them.
-     *
-     * @param reloading {@code true} when the plugin stays enabled (a {@code /lobotomy reload}). In that
-     *                  case wake work is dispatched via each villager's EntityScheduler, which reliably
-     *                  runs for cross-region (Folia) entities. On a true shutdown ({@code false}) the
-     *                  scheduler may not run, so we mutate directly and rely on the persistent marker.
+     * Stops tracking all villagers, cancels their scheduled tasks, and restores their activity state.
+     * 
+     * @param reloading {@code true} when the plugin remains enabled (such as during a config reload).
+     *                  Wake operations are dispatched via each villager's {@code EntityScheduler}, 
+     *                  ensuring safe cross-region (Folia) execution. {@code false} during plugin shutdown,
+     *                  where the scheduler may not run; in this case, mutations are attempted directly
+     *                  and the persistent lobotomized marker is relied upon for re-evaluation on chunk load.
      */
     public final void flush(boolean reloading) {
         // Prevent new tasks from being scheduled past this point
@@ -414,7 +438,11 @@ public class LobotomizeStorage {
     
     
     /**
-     * Thread-safe wrapper for processing villagers using entity scheduling
+     * Safely processes and potentially transitions a villager between active and inactive states.
+     *
+     * Validates the villager, checks its membership in the tracked sets, and evaluates whether
+     * it should toggle state. If a state transition occurs, reschedules the villager's periodic
+     * task with the appropriate check interval.
      */
     private void processVillagerSafely(@NotNull Villager villager) {
         // After flush()/reload swap, an old storage instance can still have in-flight callbacks on
@@ -467,6 +495,12 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Evaluates whether a villager should be active based on configured policy and performs state transitions as necessary.
+     *
+     * @param active whether the villager is currently in the active state
+     * @return true if the villager transitioned states or is invalid or dead; false if it remained in its current state or the chunk was unloaded
+     */
     private boolean processVillager(@NotNull Villager villager, boolean active) {
         if (!villager.isValid() || villager.isDead()) {
             return true;
@@ -554,6 +588,14 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Corrects a villager found to be in an inconsistent active/inactive state.
+     *
+     * Determines the correct state based on the villager's environment and updates its membership,
+     * awareness, and any persistent state markers accordingly.
+     *
+     * @param v the villager to reconcile
+     */
     private void reconcile(@NotNull Villager v) {
         try {
             v.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((t) -> {
@@ -590,10 +632,22 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Determines if a villager should have its trades restocked.
+     *
+     * @return {@code true} if the villager should restock, {@code false} otherwise
+     */
     private boolean shouldRestock(@NotNull Villager villager) {
         return VillagerUtils.shouldRestock(villager, this.lastRestockCheckDayTimeKey);
     }
 
+    /**
+     * Restocks the villager's trades and increases their level based on time and experience.
+     *
+     * Restock resets all merchant recipe uses when the configured interval has passed and restock
+     * conditions are met. Leveling increases the villager's level to match accumulated experience.
+     * Both operations require daytime (in the overworld) and a nearby job site.
+     */
     private void refreshTrades(@NotNull Villager villager) {
         PersistentDataContainer pdc = villager.getPersistentDataContainer();
         long lastRestock = pdc.getOrDefault(this.key, PersistentDataType.LONG, 0L);
@@ -682,6 +736,9 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Records that a block has changed, marking its chunk and edge-adjacent neighbors for deferred villager processing.
+     */
     public void handleBlockChange(Block block) {
         if (this.plugin.isDisableChunkVillagerUpdate()) {
             return;
@@ -712,6 +769,11 @@ public class LobotomizeStorage {
         }
     }
 
+    /**
+     * Schedules villager activity evaluation for recently modified chunks.
+     * Chunks are removed from tracking if they have not been modified within the past 3 seconds
+     * or are no longer loaded.
+     */
     private void processChunks() {
         long now = System.currentTimeMillis();
         changedChunks.entrySet().removeIf(entry -> {
@@ -787,22 +849,32 @@ public class LobotomizeStorage {
 
 
     /**
-     * Determines if a villager should be considered "active" based on name, vehicle, profession, and movement.
+     * Determines if a villager should be considered active.
      *
-     * @param villager The villager to check.
-     * @return true if the villager should be active, false otherwise.
+     * @return {@code true} if the villager should be active, {@code false} otherwise.
      */
     private boolean shouldBeActive(Villager villager) {
         Location loc = villager.getLocation().add(0.0F, 0.51, 0.0F);
         return shouldBeActive(villager, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
     }
 
+    /**
+     * Determines whether a villager should be active at the given block location.
+     *
+     * @return {@code true} if the villager should be active at the given location, {@code false} otherwise
+     */
     private boolean shouldBeActive(Villager villager, int blockX, int blockY, int blockZ) {
         return this.activityPolicy.shouldBeActive(
                 villagerStateOf(villager, blockX, blockY, blockZ),
                 gridOf(villager.getWorld()));
     }
 
+    /**
+     * Builds a state representation of a villager at the given block coordinates.
+     *
+     * @return a VillagerState containing the villager's name, swimming and sleeping status,
+     *         vehicle presence, profession, experience, and block coordinates
+     */
     private VillagerState villagerStateOf(Villager villager, int blockX, int blockY, int blockZ) {
         Component customName = villager.customName();
         String name = customName == null
@@ -840,6 +912,11 @@ public class LobotomizeStorage {
             private int cachedChunkX;
             private int cachedChunkZ;
 
+            /**
+             * Gets a block snapshot at the specified world coordinates, caching chunk lookups for efficiency.
+             *
+             * @return a snapshot of the block at the coordinates, or null if the chunk is not loaded
+             */
             @Override
             public BlockSnapshot at(int x, int y, int z) {
                 int chunkX = x >> 4;
@@ -861,6 +938,13 @@ public class LobotomizeStorage {
         };
     }
 
+    /**
+     * Converts a legacy sound name format and updates the config if a conversion is needed.
+     *
+     * @param soundName the sound name to convert
+     * @param configKey the configuration key to update if conversion occurs
+     * @return the converted sound name, or an empty string if the conversion fails
+     */
     private String convertLegacySoundName(String soundName, String configKey) {
         String converted = StringUtils.convertLegacySoundNameFormat(soundName);
         if (converted == null) {
@@ -893,7 +977,15 @@ public class LobotomizeStorage {
     }
 
     /**
-     * Schedule a villager with the given interval, replacing any existing task.
+     * Schedules periodic processing of a villager at the specified interval,
+     * replacing any existing task.
+     *
+     * Does nothing if the plugin is disabled or shutting down. If the villager
+     * is no longer tracked, the scheduling is skipped. If a plugin access
+     * exception occurs, the villager is untracked.
+     *
+     * @param villager the villager to schedule
+     * @param interval the scheduling period in ticks
      */
     private void scheduleVillagerTask(@NotNull Villager villager, long interval) {
         if (this.shuttingDown || !this.plugin.isEnabled()) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -59,68 +59,13 @@ public final class VillagerLobotomizer extends JavaPlugin {
         } else {
             this.getLogger().info("Update checker is disabled. You will not be notified of new versions.");
         }
-        // Detect if we're running on Folia
         this.isFolia = this.detectFolia();
         if (this.isFolia) {
             this.getLogger().info("Folia detected, using per-entity schedulers.");
         }
 
-        // Initialize Sentry if enabled
-        boolean enableSentry = this.getConfig().getBoolean("enable-sentry", true);
-        if (enableSentry) {
-            // Check if Sentry is already initialized (e.g., from a previous plugin reload)
-            if (Sentry.isEnabled()) {
-                this.sentryEnabled = true;
-                this.getLogger().info("Sentry is already initialized, skipping re-initialization");
-            } else {
-                // Detect if we're running in dev mode (runServer task)
-                boolean isDev = Boolean.getBoolean("villagerlobotimizer.dev");
-                String environment = isDev ? "development" : "production";
-
-                try {
-                    Sentry.init(options -> {
-                        options.setDsn("https://fdd79b92bf9f83a2f9699e844c080019@o1234338.ingest.us.sentry.io/4510592886702080");
-                        options.setEnvironment(environment);
-                        options.setRelease("villagerlobotimizer@" + this.getPluginMeta().getVersion());
-
-                        // Set context tags
-                        try {
-                            options.setTag("server.brand", SentryContextProvider.getServerBrand());
-                            options.setTag("server.version", SentryContextProvider.getServerVersion());
-                            options.setTag("minecraft.version", SentryContextProvider.getMinecraftVersion());
-                            options.setTag("bukkit.version", SentryContextProvider.getBukkitVersion());
-                            options.setTag("java.version", SentryContextProvider.getJavaVersion());
-                            options.setTag("folia.enabled", String.valueOf(this.isFolia));
-                        } catch (Exception e) {
-                            this.getLogger().log(java.util.logging.Level.WARNING, "Failed to set Sentry context tags: " + e.getMessage(), e);
-                        }
-
-                        // Enable source context and stack traces
-                        options.setAttachStacktrace(true); // Attach stack traces to all events
-                        options.setAttachThreads(true); // Attach thread information
-
-                        // Mark our package as in-app for better source highlighting
-                        options.addInAppInclude("dev.mja00.villagerLobotimizer");
-
-                        // Performance monitoring
-                        options.setTracesSampleRate(0.1); // 10% sampling
-
-                        // Privacy: disable PII
-                        options.setSendDefaultPii(false);
-
-                        // Disable uncaught exception handler
-                        options.setEnableUncaughtExceptionHandler(false);
-                    });
-                    this.sentryEnabled = true;
-                    this.getLogger().info("Sentry error tracking enabled (environment: " + environment + ")");
-                } catch (Exception e) {
-                    this.getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize Sentry: " + e.getMessage(), e);
-                    this.sentryEnabled = false;
-                }
-            }
-        } else {
-            this.getLogger().info("Sentry error tracking is disabled in config");
-        }
+        // Initialize Sentry to match config (also handles enable/disable transitions on reload)
+        this.applySentryConfig();
 
         this.storage = new LobotomizeStorage(this);
         this.getServer().getPluginManager().registerEvents(new EntityListener(this), this);
@@ -128,7 +73,6 @@ public final class VillagerLobotomizer extends JavaPlugin {
         this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, command -> {
             command.registrar().register(lobotomizeCommand.createCommand("lobotomy"));
         });
-        // Set our debugs based on the config
         this.debugging = this.getConfig().getBoolean("debug");
         this.chunkDebugging = this.getConfig().getBoolean("chunk-debug");
         this.disableChunkVillagerUpdate = this.getConfig().getBoolean("disable-chunk-villager-updates");
@@ -187,13 +131,10 @@ public final class VillagerLobotomizer extends JavaPlugin {
             this.getLogger().info(String.format("Status determining class: %s", VersionUtils.getSupportStatusClass()));
         }
 
-        // Plugin startup logic
         getLogger().info("I'm ready to lobotomize your villagers!");
         if (this.isDebugging()) {
             getLogger().info("Debug mode is enabled. This will print debug messages to the console.");
-            // Ensure two teams are created for debugging purposes, active and inactive villagers
-            // Colors for the teams are green and red respectively
-            // This way we can toggle glow on them in debug mode
+            // Active/inactive teams let us toggle glow on villagers in debug mode
             if (createDebuggingTeams) {
                 createDebuggingTeams();
             }
@@ -253,13 +194,12 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
         getLogger().info("Man guess I'll put my tools away now :(");
         if (this.storage != null) {
             this.storage.flush();
         }
         // No need to cancel tasks manually - Paper handles this automatically on disable
-        // If either of the teams are not null, we need to remove them (only on non-Folia servers)
+        // Clean up debug teams (non-Folia only)
         if (!this.isFolia) {
             ScoreboardManager scoreboardManager = this.getServer().getScoreboardManager();
             if (scoreboardManager != null) {
@@ -272,7 +212,6 @@ public final class VillagerLobotomizer extends JavaPlugin {
             }
         }
 
-        // Flush and close Sentry
         if (this.sentryEnabled) {
             try {
                 Sentry.close();
@@ -287,7 +226,7 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
     private void clearTeam(Team team) {
         if (team != null) {
-            // Get all entities on the team and unglow them just in case
+            // Unglow entries before unregistering
             for (String entry : team.getEntries()) {
                 UUID uuid = UUID.fromString(entry);
                 Entity entity = this.getServer().getEntity(uuid);
@@ -314,7 +253,6 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
         // Skip team operations on Folia
         if (!this.isFolia) {
-            // If debugging is being set to false, we need to clean up the teams
             if (!debugging) {
                 ScoreboardManager scoreboardManager = this.getServer().getScoreboardManager();
                 if (scoreboardManager != null) {
@@ -328,14 +266,12 @@ public final class VillagerLobotomizer extends JavaPlugin {
                 this.activeVillagersTeam = null;
                 this.inactiveVillagersTeam = null;
             } else {
-                // Create them again
                 createDebuggingTeams();
             }
         } else if (debugging) {
             this.getLogger().info("Debug mode enabled. Note: Villager teams/glowing are not available on Folia.");
         }
 
-        // Update the config
         this.getConfig().set("debug", this.debugging);
         this.saveConfig();
     }
@@ -346,7 +282,6 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
     public void setChunkDebugging(boolean chunkDebugging) {
         this.chunkDebugging = chunkDebugging;
-        // Update the config
         this.getConfig().set("chunk-debug", this.chunkDebugging);
         this.saveConfig();
     }
@@ -357,8 +292,7 @@ public final class VillagerLobotomizer extends JavaPlugin {
 
 
     private void checkForUpdates() {
-        // We need to GET the url. It returns an array of objects for each version
-        // This'll be scheduled off thread so no need to worry here
+        // Runs off-thread via async scheduler
         String currentVersion = this.getPluginMeta().getVersion();
         this.getLogger().info("Checking for updates...");
         VillagerLobotomizer plugin = this;
@@ -375,13 +309,12 @@ public final class VillagerLobotomizer extends JavaPlugin {
                 plugin.getLogger().warning("Failed to check for updates: No response from the server");
                 return;
             }
-            // Parse our response into json and filter to only release versions (ignore beta/alpha)
+            // Parse the version list response
             List<Modrinth.ModrinthVersion> versions = Modrinth.fromJson(responseBody);
             if (versions == null || versions.isEmpty()) {
                 plugin.getLogger().warning("Failed to check for updates: No versions found");
                 return;
             }
-            // Only consider versions where version_type is "release"
             Modrinth.ModrinthVersion latestVersion = versions.stream()
                     .filter(v -> "release".equalsIgnoreCase(v.getVersionType()))
                     .findFirst()
@@ -392,7 +325,6 @@ public final class VillagerLobotomizer extends JavaPlugin {
             }
 
 
-            // Compare versions using proper semantic versioning
             int comparison = dev.mja00.villagerLobotomizer.utils.StringUtils.compareSemVer(currentVersion, latestVersion.getVersionNumber());
             if (comparison < 0) {
                 plugin.getLogger().info("A new version of VillagerLobotomizer is available! (" + latestVersion.getVersionNumber() + ")");
@@ -439,12 +371,88 @@ public final class VillagerLobotomizer extends JavaPlugin {
     }
 
     /**
+     * Initializes or shuts down Sentry to match the current {@code enable-sentry} config value.
+     * Safe to call on enable and on {@code /lobotomy reload}; handles transitions in both directions.
+     */
+    private void applySentryConfig() {
+        boolean enableSentry = this.getConfig().getBoolean("enable-sentry", true);
+        if (enableSentry) {
+            // Already initialized (e.g. fresh enable after a soft plugin reload, or a prior reload)
+            if (Sentry.isEnabled()) {
+                this.sentryEnabled = true;
+                this.getLogger().info("Sentry is already initialized, skipping re-initialization");
+                return;
+            }
+            initializeSentry();
+        } else {
+            // Disabled in config: close it if it was previously running so a reload takes effect.
+            if (this.sentryEnabled || Sentry.isEnabled()) {
+                try {
+                    Sentry.close();
+                    if (this.isDebugging()) {
+                        this.getLogger().info("Sentry shutdown complete (disabled via config)");
+                    }
+                } catch (Exception e) {
+                    this.getLogger().log(java.util.logging.Level.WARNING, "Error during Sentry shutdown: " + e.getMessage(), e);
+                }
+            }
+            this.sentryEnabled = false;
+            this.getLogger().info("Sentry error tracking is disabled in config");
+        }
+    }
+
+    private void initializeSentry() {
+        // dev mode set by the runServer task
+        boolean isDev = Boolean.getBoolean("villagerlobotimizer.dev");
+        String environment = isDev ? "development" : "production";
+
+        try {
+            Sentry.init(options -> {
+                options.setDsn("https://fdd79b92bf9f83a2f9699e844c080019@o1234338.ingest.us.sentry.io/4510592886702080");
+                options.setEnvironment(environment);
+                options.setRelease("villagerlobotimizer@" + this.getPluginMeta().getVersion());
+
+                try {
+                    options.setTag("server.brand", SentryContextProvider.getServerBrand());
+                    options.setTag("server.version", SentryContextProvider.getServerVersion());
+                    options.setTag("minecraft.version", SentryContextProvider.getMinecraftVersion());
+                    options.setTag("bukkit.version", SentryContextProvider.getBukkitVersion());
+                    options.setTag("java.version", SentryContextProvider.getJavaVersion());
+                    options.setTag("folia.enabled", String.valueOf(this.isFolia));
+                } catch (Exception e) {
+                    this.getLogger().log(java.util.logging.Level.WARNING, "Failed to set Sentry context tags: " + e.getMessage(), e);
+                }
+
+                options.setAttachStacktrace(true);
+                options.setAttachThreads(true);
+
+                // Mark our package as in-app for better source highlighting
+                options.addInAppInclude("dev.mja00.villagerLobotimizer");
+
+                options.setTracesSampleRate(0.1);
+
+                // Privacy: disable PII
+                options.setSendDefaultPii(false);
+
+                options.setEnableUncaughtExceptionHandler(false);
+            });
+            this.sentryEnabled = true;
+            this.getLogger().info("Sentry error tracking enabled (environment: " + environment + ")");
+        } catch (Exception e) {
+            this.getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize Sentry: " + e.getMessage(), e);
+            this.sentryEnabled = false;
+        }
+    }
+
+    /**
      * Reloads plugin configuration, storage, and debug flags.
      *
      * @return number of villagers reloaded into storage
      */
     public int reloadPluginState() {
         this.reloadConfig();
+        // Apply enable-sentry transitions on reload (init if newly enabled, close if newly disabled).
+        this.applySentryConfig();
         this.debugging = this.getConfig().getBoolean("debug");
         this.chunkDebugging = this.getConfig().getBoolean("chunk-debug");
         this.disableChunkVillagerUpdate = this.getConfig().getBoolean("disable-chunk-villager-updates");
@@ -464,11 +472,12 @@ public final class VillagerLobotomizer extends JavaPlugin {
         }
 
         if (previousStorage != null) {
-            previousStorage.flush();
+            // Reload: plugin stays enabled, so dispatch wake work via the entity scheduler (Folia-safe).
+            previousStorage.flush(true);
         }
         this.storage = newStorage;
 
-        // Reset or recreate debug teams based on current configuration
+        // Reset/recreate debug teams per current config
         if (!this.isFolia) {
             ScoreboardManager scoreboardManager = this.getServer().getScoreboardManager();
             if (scoreboardManager != null) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -458,7 +458,7 @@ public final class VillagerLobotomizer extends JavaPlugin {
                 options.setAttachThreads(true);
 
                 // Mark our package as in-app for better source highlighting
-                options.addInAppInclude("dev.mja00.villagerLobotimizer");
+                options.addInAppInclude("dev.mja00.villagerLobotomizer");
 
                 options.setTracesSampleRate(0.1);
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -49,6 +49,9 @@ public final class VillagerLobotomizer extends JavaPlugin {
     private boolean disableChunkVillagerUpdate;
     private boolean sentryEnabled = false;
 
+    /**
+     * Initializes the plugin, loading configuration, storage, listeners, commands, and debug features.
+     */
     @Override
     public void onEnable() {
         ConfigMigrator migrator = new ConfigMigrator(this);
@@ -224,6 +227,9 @@ public final class VillagerLobotomizer extends JavaPlugin {
         }
     }
 
+    /**
+     * Removes all villagers from a team, unglows them, and unregisters the team.
+     */
     private void clearTeam(Team team) {
         if (team != null) {
             // Unglow entries before unregistering
@@ -248,6 +254,11 @@ public final class VillagerLobotomizer extends JavaPlugin {
         return this.debugging;
     }
 
+    /**
+     * Enables or disables debug mode and updates debug teams if running on a non-Folia server.
+     *
+     * @param debugging true to enable debug mode, false to disable
+     */
     public void setDebugging(boolean debugging) {
         this.debugging = debugging;
 
@@ -280,6 +291,11 @@ public final class VillagerLobotomizer extends JavaPlugin {
         return this.chunkDebugging;
     }
 
+    /**
+     * Enables or disables chunk debugging and persists the setting.
+     *
+     * @param chunkDebugging whether chunk debugging should be enabled
+     */
     public void setChunkDebugging(boolean chunkDebugging) {
         this.chunkDebugging = chunkDebugging;
         this.getConfig().set("chunk-debug", this.chunkDebugging);
@@ -291,6 +307,9 @@ public final class VillagerLobotomizer extends JavaPlugin {
     }
 
 
+    /**
+     * Checks Modrinth for a newer version of the plugin and flags if an update is available.
+     */
     private void checkForUpdates() {
         // Runs off-thread via async scheduler
         String currentVersion = this.getPluginMeta().getVersion();
@@ -366,13 +385,18 @@ public final class VillagerLobotomizer extends JavaPlugin {
         return this.disableChunkVillagerUpdate;
     }
 
+    /**
+     * Checks if Sentry error tracking is enabled.
+     *
+     * @return {@code true} if Sentry is enabled, {@code false} otherwise
+     */
     public boolean isSentryEnabled() {
         return this.sentryEnabled;
     }
 
     /**
-     * Initializes or shuts down Sentry to match the current {@code enable-sentry} config value.
-     * Safe to call on enable and on {@code /lobotomy reload}; handles transitions in both directions.
+     * Initializes or shuts down Sentry to match the current {@code enable-sentry} configuration value.
+     * Transitions safely in both directions and is idempotent.
      */
     private void applySentryConfig() {
         boolean enableSentry = this.getConfig().getBoolean("enable-sentry", true);
@@ -401,6 +425,13 @@ public final class VillagerLobotomizer extends JavaPlugin {
         }
     }
 
+    /**
+     * Initializes the Sentry error tracking SDK with project configuration.
+     *
+     * Configures Sentry with DSN, environment (determined by the {@code villagerlobotimizer.dev}
+     * system property), release tag, and server context tags. Sets {@code sentryEnabled} to
+     * {@code true} on success, or {@code false} and logs a warning on failure.
+     */
     private void initializeSentry() {
         // dev mode set by the runServer task
         boolean isDev = Boolean.getBoolean("villagerlobotimizer.dev");
@@ -445,9 +476,9 @@ public final class VillagerLobotomizer extends JavaPlugin {
     }
 
     /**
-     * Reloads plugin configuration, storage, and debug flags.
+     * Reloads configuration, reinitializes storage, and rescans all worlds for villagers.
      *
-     * @return number of villagers reloaded into storage
+     * @return the number of villagers added to storage, or -1 if storage recreation fails
      */
     public int reloadPluginState() {
         this.reloadConfig();

--- a/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
@@ -94,6 +94,12 @@ public class EntityListener implements Listener {
         this.plugin.getStorage().handleBlockChange(event.getBlock());
     }
 
+    /**
+     * Prevents players from trading with unlobotomized villagers if the prevention feature is enabled.
+     *
+     * Sends the player a configured message when trading is blocked, falling back to a default
+     * message if the configuration message fails to parse as MiniMessage.
+     */
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public final void onInventoryOpen(InventoryOpenEvent event) {
         if (!this.plugin.getConfig().getBoolean("prevent-trading-with-unlobotomized-villagers", false)) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
@@ -96,12 +96,10 @@ public class EntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public final void onInventoryOpen(InventoryOpenEvent event) {
-        // Check if the feature is enabled in config
         if (!this.plugin.getConfig().getBoolean("prevent-trading-with-unlobotomized-villagers", false)) {
             return;
         }
 
-        // Only handle merchant (trading) inventories
         if (!(event.getInventory() instanceof MerchantInventory merchantInventory)) {
             return;
         }
@@ -111,17 +109,15 @@ public class EntityListener implements Listener {
             return;
         }
 
-        // Only block trades with tracked, unlobotomized (active) villagers
+        // active set == tracked, unlobotomized villagers
         if (!this.plugin.getStorage().getActive().contains(villager)) {
             return;
         }
 
-        // Prevent the trade GUI from opening
         event.setCancelled(true);
 
         Player player = (Player) event.getPlayer();
 
-        // Send a message to the player explaining why the trade was blocked
         String messageString = this.plugin.getConfig().getString("unlobotomized-villager-trade-message", DEFAULT_TRADE_MESSAGE);
         if (messageString == null) {
             messageString = DEFAULT_TRADE_MESSAGE;

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockClassifier.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockClassifier.java
@@ -1,0 +1,62 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+import dev.mja00.villagerLobotomizer.utils.VillagerUtils;
+import org.bukkit.Material;
+import org.bukkit.Registry;
+import org.bukkit.block.data.Ageable;
+
+import java.util.EnumSet;
+
+/**
+ * Holds the precomputed Material sets the activity policy tests membership against.
+ */
+public record BlockClassifier(
+        EnumSet<Material> impassableRegular,
+        EnumSet<Material> impassableTall,
+        EnumSet<Material> impassableAll,
+        EnumSet<Material> cropBlocks,
+        EnumSet<Material> doorBlocks,
+        EnumSet<Material> professionBlocks) {
+
+    public static BlockClassifier fromServerRegistry() {
+        EnumSet<Material> impassableRegular = EnumSet.of(Material.LAVA);
+        EnumSet<Material> impassableFloor = EnumSet.noneOf(Material.class);
+        EnumSet<Material> impassableTall = EnumSet.noneOf(Material.class);
+        EnumSet<Material> doorBlocks = EnumSet.noneOf(Material.class);
+        EnumSet<Material> cropBlocks = EnumSet.noneOf(Material.class);
+
+        for (Material m : Registry.MATERIAL) {
+            if (m.isOccluding()) {
+                impassableRegular.add(m);
+            }
+            if (m.name().contains("_CARPET")) {
+                impassableFloor.add(m);
+            }
+            if (m.name().contains("_WALL") || m.name().contains("_FENCE")) {
+                impassableTall.add(m);
+            }
+            if (m.name().contains("_DOOR")) {
+                doorBlocks.add(m);
+            }
+            // Identify crops once; createBlockData() can throw for non-standard materials.
+            if (m.isBlock()) {
+                try {
+                    if (m.createBlockData() instanceof Ageable) {
+                        cropBlocks.add(m);
+                    }
+                } catch (Exception ignored) {
+                    // Material cannot produce block data; not a crop.
+                }
+            }
+        }
+
+        EnumSet<Material> impassableAll = EnumSet.copyOf(impassableRegular);
+        impassableAll.addAll(impassableFloor);
+        impassableAll.addAll(impassableTall);
+
+        EnumSet<Material> professionBlocks = VillagerUtils.professionStationMaterials();
+
+        return new BlockClassifier(impassableRegular, impassableTall,
+                impassableAll, cropBlocks, doorBlocks, professionBlocks);
+    }
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockClassifier.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockClassifier.java
@@ -18,6 +18,12 @@ public record BlockClassifier(
         EnumSet<Material> doorBlocks,
         EnumSet<Material> professionBlocks) {
 
+    /**
+     * Builds a BlockClassifier by scanning the server's material registry and classifying materials.
+     *
+     * @return A BlockClassifier containing precomputed material classifications for impassability,
+     *         crops, doors, and profession stations.
+     */
     public static BlockClassifier fromServerRegistry() {
         EnumSet<Material> impassableRegular = EnumSet.of(Material.LAVA);
         EnumSet<Material> impassableFloor = EnumSet.noneOf(Material.class);

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockGrid.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockGrid.java
@@ -1,0 +1,10 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+/**
+ * Supplies block snapshots by world coordinate. Implementations return {@code null} when the
+ * coordinate's chunk is not loaded/available, which the policy treats as "cannot move there".
+ */
+@FunctionalInterface
+public interface BlockGrid {
+    BlockSnapshot at(int x, int y, int z);
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockGrid.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockGrid.java
@@ -6,5 +6,13 @@ package dev.mja00.villagerLobotomizer.policy;
  */
 @FunctionalInterface
 public interface BlockGrid {
-    BlockSnapshot at(int x, int y, int z);
+    /**
+ * Retrieves the block snapshot at the specified world coordinates.
+ *
+ * @param x the x-coordinate
+ * @param y the y-coordinate
+ * @param z the z-coordinate
+ * @return the block snapshot at the specified coordinates, or {@code null} if the corresponding chunk is not loaded or available
+ */
+BlockSnapshot at(int x, int y, int z);
 }

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockSnapshot.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/BlockSnapshot.java
@@ -1,0 +1,10 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+import org.bukkit.Material;
+
+/**
+ * Immutable view of a block as the activity policy needs it: its material, whether an entity can
+ * pass through it (Block#isPassable), and whether the material is solid (Material#isSolid).
+ */
+public record BlockSnapshot(Material type, boolean passable, boolean solid) {
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
@@ -33,7 +33,8 @@ public final class VillagerActivityPolicy {
         this.checkRoof = checkRoof;
         this.ignoreStuckInDoors = ignoreStuckInDoors;
         this.ignoreNonSolidBlocks = ignoreNonSolidBlocks;
-        this.exemptNames = exemptNames;
+        // Defensive immutable copy so later caller mutations can't alter policy decisions.
+        this.exemptNames = Set.copyOf(exemptNames);
         this.blocks = blocks;
     }
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
@@ -20,6 +20,9 @@ public final class VillagerActivityPolicy {
     private final Set<String> exemptNames;
     private final BlockClassifier blocks;
 
+    /**
+     * Creates a new activity policy with the specified configuration.
+     */
     public VillagerActivityPolicy(boolean lobotomizePassengers, boolean onlyProfessions,
                                   boolean onlyWithExperience, boolean checkRoof,
                                   boolean ignoreStuckInDoors, boolean ignoreNonSolidBlocks,
@@ -34,6 +37,13 @@ public final class VillagerActivityPolicy {
         this.blocks = blocks;
     }
 
+    /**
+     * Determines whether a villager should be active based on its state and environment.
+     *
+     * @param v the villager's current state
+     * @param grid the surrounding block grid
+     * @return {@code true} if the villager should be active, {@code false} if it should be lobotomized
+     */
     public boolean shouldBeActive(VillagerState v, BlockGrid grid) {
         String name = v.name();
         if (name.contains("nobrain")) {
@@ -82,6 +92,11 @@ public final class VillagerActivityPolicy {
         return canMoveCardinally(grid, v.blockX(), v.blockY(), v.blockZ(), hasRoof);
     }
 
+    /**
+     * Determines whether the villager can move in any cardinal direction from the specified position.
+     *
+     * @return true if at least one cardinal direction is passable, false otherwise
+     */
     private boolean canMoveCardinally(BlockGrid grid, int x, int y, int z, boolean roof) {
         boolean xPlus = canMoveThrough(grid, x + 1, y, z, roof);
         boolean xMinus = canMoveThrough(grid, x - 1, y, z, roof);
@@ -90,6 +105,13 @@ public final class VillagerActivityPolicy {
         return xPlus || xMinus || zPlus || zMinus;
     }
 
+    /**
+     * Determines whether a villager can move through a given block position.
+     *
+     * @param grid the block grid to query
+     * @param roof whether the under-feet block must be passable
+     * @return `true` if the villager can pass through the position, `false` otherwise
+     */
     private boolean canMoveThrough(BlockGrid grid, int x, int y, int z, boolean roof) {
         BlockSnapshot head = grid.at(x, y + 1, z);
         BlockSnapshot feet = grid.at(x, y, z);
@@ -103,6 +125,14 @@ public final class VillagerActivityPolicy {
         return !isHeadImpassable && !isFeetImpassable && (!roof || !isUnderFeetImpassable);
     }
 
+    /**
+     * Determines whether a block should be treated as impassable.
+     *
+     * @param set             materials to classify as impassable
+     * @param b               the block to evaluate
+     * @param onlyTallBlocks  if true, blocks not in the set are never considered impassable
+     * @return                true if the block is impassable, false otherwise
+     */
     private boolean testImpassable(EnumSet<Material> set, BlockSnapshot b, boolean onlyTallBlocks) {
         if (b == null) {
             return false;
@@ -125,6 +155,12 @@ public final class VillagerActivityPolicy {
         return !isWater && !b.passable() && !isABypassBlock && !isNonSolid;
     }
 
+    /**
+     * Determines if a block is water.
+     *
+     * @param  b the block to check
+     * @return   {@code true} if the block is water, {@code false} otherwise
+     */
     private static boolean isWater(BlockSnapshot b) {
         return b != null && b.type() == Material.WATER;
     }

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicy.java
@@ -1,0 +1,131 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+import org.bukkit.Material;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Pure decision logic for whether a villager should keep its AI ("active") or be lobotomized
+ * ("inactive"). 
+ */
+public final class VillagerActivityPolicy {
+
+    private final boolean lobotomizePassengers;
+    private final boolean onlyProfessions;
+    private final boolean onlyWithExperience;
+    private final boolean checkRoof;
+    private final boolean ignoreStuckInDoors;
+    private final boolean ignoreNonSolidBlocks;
+    private final Set<String> exemptNames;
+    private final BlockClassifier blocks;
+
+    public VillagerActivityPolicy(boolean lobotomizePassengers, boolean onlyProfessions,
+                                  boolean onlyWithExperience, boolean checkRoof,
+                                  boolean ignoreStuckInDoors, boolean ignoreNonSolidBlocks,
+                                  Set<String> exemptNames, BlockClassifier blocks) {
+        this.lobotomizePassengers = lobotomizePassengers;
+        this.onlyProfessions = onlyProfessions;
+        this.onlyWithExperience = onlyWithExperience;
+        this.checkRoof = checkRoof;
+        this.ignoreStuckInDoors = ignoreStuckInDoors;
+        this.ignoreNonSolidBlocks = ignoreNonSolidBlocks;
+        this.exemptNames = exemptNames;
+        this.blocks = blocks;
+    }
+
+    public boolean shouldBeActive(VillagerState v, BlockGrid grid) {
+        String name = v.name();
+        if (name.contains("nobrain")) {
+            return false;
+        } else if (this.exemptNames.contains(name)) {
+            return true;
+        }
+
+        if (v.swimming()) {
+            return true;
+        }
+
+        BlockSnapshot feet = grid.at(v.blockX(), v.blockY(), v.blockZ());
+        BlockSnapshot head = grid.at(v.blockX(), v.blockY() + 1, v.blockZ());
+        if (isWater(feet) || isWater(head)) {
+            return true;
+        }
+
+        if (v.sleeping()) {
+            return true;
+        }
+
+        if (this.lobotomizePassengers && v.hasVehicle()) {
+            return false;
+        }
+
+        if (this.onlyProfessions && v.professionNone()) {
+            return true;
+        }
+
+        if (this.onlyWithExperience && v.experience() == 0) {
+            return true;
+        }
+
+        BlockSnapshot floor = grid.at(v.blockX(), v.blockY() - 1, v.blockZ());
+        BlockSnapshot roof = grid.at(v.blockX(), v.blockY() + 2, v.blockZ());
+
+        if (this.checkRoof && (roof == null || roof.type() == Material.AIR)) {
+            return true;
+        }
+
+        Material floorMaterial = floor == null ? Material.AIR : floor.type();
+        boolean hasRoof = floorMaterial == Material.HONEY_BLOCK
+                || testImpassable(this.blocks.impassableAll(), roof, false);
+
+        return canMoveCardinally(grid, v.blockX(), v.blockY(), v.blockZ(), hasRoof);
+    }
+
+    private boolean canMoveCardinally(BlockGrid grid, int x, int y, int z, boolean roof) {
+        boolean xPlus = canMoveThrough(grid, x + 1, y, z, roof);
+        boolean xMinus = canMoveThrough(grid, x - 1, y, z, roof);
+        boolean zPlus = canMoveThrough(grid, x, y, z + 1, roof);
+        boolean zMinus = canMoveThrough(grid, x, y, z - 1, roof);
+        return xPlus || xMinus || zPlus || zMinus;
+    }
+
+    private boolean canMoveThrough(BlockGrid grid, int x, int y, int z, boolean roof) {
+        BlockSnapshot head = grid.at(x, y + 1, z);
+        BlockSnapshot feet = grid.at(x, y, z);
+        BlockSnapshot underFeet = grid.at(x, y - 1, z);
+        if (head == null || feet == null || underFeet == null) {
+            return false;
+        }
+        boolean isHeadImpassable = testImpassable(this.blocks.impassableRegular(), head, false);
+        boolean isFeetImpassable = testImpassable(this.blocks.impassableRegular(), feet, false);
+        boolean isUnderFeetImpassable = testImpassable(this.blocks.impassableTall(), underFeet, true);
+        return !isHeadImpassable && !isFeetImpassable && (!roof || !isUnderFeetImpassable);
+    }
+
+    private boolean testImpassable(EnumSet<Material> set, BlockSnapshot b, boolean onlyTallBlocks) {
+        if (b == null) {
+            return false;
+        }
+        Material type = b.type();
+        if (set.contains(type)) {
+            return true;
+        }
+        if (onlyTallBlocks) {
+            return false;
+        }
+        boolean isCarpet = type.name().contains("_CARPET");
+        boolean isBed = type.name().contains("_BED");
+        boolean isWater = type == Material.WATER;
+        boolean isCrop = this.blocks.cropBlocks().contains(type);
+        boolean isABypassBlock = (isCrop || isBed || isCarpet
+                || (this.ignoreStuckInDoors && this.blocks.doorBlocks().contains(type)));
+        boolean isNonSolid = !b.solid() && this.ignoreNonSolidBlocks
+                && !this.blocks.professionBlocks().contains(type);
+        return !isWater && !b.passable() && !isABypassBlock && !isNonSolid;
+    }
+
+    private static boolean isWater(BlockSnapshot b) {
+        return b != null && b.type() == Material.WATER;
+    }
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerState.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/policy/VillagerState.java
@@ -1,0 +1,18 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+/**
+ * Plain snapshot of the villager properties the activity policy needs. {@code name} is the
+ * plain-text custom name, lowercased, or "" when the villager has no custom name. Coordinates are
+ * the block the villager occupies (already offset/floored by the caller).
+ */
+public record VillagerState(
+        String name,
+        boolean swimming,
+        boolean sleeping,
+        boolean hasVehicle,
+        boolean professionNone,
+        int experience,
+        int blockX,
+        int blockY,
+        int blockZ) {
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/CommentPreservingYamlMigrator.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/CommentPreservingYamlMigrator.java
@@ -22,8 +22,16 @@ public class CommentPreservingYamlMigrator {
     }
 
     /**
-     * Merges existing config with default config, preserving comments from both.
-     * User comments are preserved, and comments from default config are added for new fields.
+     * Merges default YAML configuration with existing YAML while preserving comments from both.
+     *
+     * <p>User comments from the existing YAML are preserved for matching keys. Comments from
+     * the default YAML are added for new keys and sections not present in the existing YAML.
+     * Extra keys from the existing YAML that are not in the default are preserved in the output.
+     *
+     * @param existingYaml the existing YAML configuration
+     * @param defaultYaml  the default YAML configuration to merge
+     * @return the merged YAML as a string with comments from both sources
+     * @throws IOException if the merge process fails
      */
     public String mergeWithComments(String existingYaml, String defaultYaml) throws IOException {
         try {
@@ -60,6 +68,9 @@ public class CommentPreservingYamlMigrator {
         }
     }
 
+    /**
+     * Recursively merges default YAML configuration into existing configuration, preserving comments and extra keys.
+     */
     @SuppressWarnings("unchecked")
     private void mergeRecursive(String path, Map<String, Object> existing, Map<String, Object> defaults,
                                Map<String, Object> merged, Map<String, String> existingComments,
@@ -125,6 +136,17 @@ public class CommentPreservingYamlMigrator {
         }
     }
 
+    /**
+     * Extracts comments from YAML content and associates them with keys.
+     *
+     * Comments appearing before the first detected key are treated as header comments.
+     * Subsequent full-line comments are buffered and attached to the following key line,
+     * identified by dot-separated paths based on indentation nesting.
+     *
+     * @param yamlContent the YAML content to parse
+     * @return a CommentedYamlData object containing the mapping of dot-path keys to their comments
+     *         and a list of header comments
+     */
     private CommentedYamlData parseWithComments(String yamlContent) {
         Map<String, String> comments = new LinkedHashMap<>();
         List<String> headerComments = new ArrayList<>();
@@ -172,6 +194,13 @@ public class CommentPreservingYamlMigrator {
         return new CommentedYamlData(comments, headerComments);
     }
 
+    /**
+     * Determines the dot-separated key path for a YAML line based on its nesting context.
+     *
+     * @param lines     the YAML content split into lines
+     * @param lineIndex the index of the line for which to extract the key path
+     * @return          the dot-separated key path representing the nested structure, or an empty string if no keys are found
+     */
     private String extractKeyPath(String[] lines, int lineIndex) {
         Stack<String> pathStack = new Stack<>();
         Stack<Integer> indentStack = new Stack<>();
@@ -214,6 +243,12 @@ public class CommentPreservingYamlMigrator {
         return indent;
     }
 
+    /**
+     * Extracts the YAML key from a line, removing surrounding quotes.
+     *
+     * @param line the YAML line to parse
+     * @return the key portion before the first colon, with surrounding quotes removed, or {@code null} if no colon is found
+     */
     private String extractKey(String line) {
         String trimmed = line.trim();
         if (trimmed.contains(":")) {
@@ -228,6 +263,14 @@ public class CommentPreservingYamlMigrator {
         return null;
     }
 
+    /**
+     * Generates a YAML string with comments attached to keys.
+     *
+     * @param data the YAML data structure to serialize
+     * @param comments mapping from dot-separated key paths to comment strings
+     * @param headerComments comments to include at the start of the output
+     * @return the formatted YAML string with comments
+     */
     private String generateYamlWithComments(Map<String, Object> data, Map<String, String> comments, List<String> headerComments) {
         StringBuilder result = new StringBuilder();
 
@@ -244,6 +287,12 @@ public class CommentPreservingYamlMigrator {
         return result.toString();
     }
 
+    /**
+     * Serializes a YAML section with attached comments at the specified indentation level.
+     *
+     * @param comments map of dot-separated key paths to comment strings
+     * @param pathPrefix the current dot-separated key path prefix for looking up comments
+     */
     @SuppressWarnings("unchecked")
     private void generateYamlSection(Map<String, Object> data, Map<String, String> comments,
                                    StringBuilder result, String pathPrefix, int indentLevel) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/CommentPreservingYamlMigrator.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/CommentPreservingYamlMigrator.java
@@ -29,14 +29,12 @@ public class CommentPreservingYamlMigrator {
         try {
             logger.fine("Starting comment-preserving YAML merge");
 
-            // Parse both YAML files with comment information
             CommentedYamlData existingData = parseWithComments(existingYaml);
             CommentedYamlData defaultData = parseWithComments(defaultYaml);
 
             logger.fine("Extracted " + existingData.comments.size() + " comments from existing config");
             logger.fine("Extracted " + defaultData.comments.size() + " comments from default config");
 
-            // Parse actual data structures
             Yaml yaml = new Yaml();
             Map<String, Object> existingMap = yaml.load(existingYaml);
             Map<String, Object> defaultMap = yaml.load(defaultYaml);
@@ -44,16 +42,13 @@ public class CommentPreservingYamlMigrator {
             if (existingMap == null) existingMap = new LinkedHashMap<>();
             if (defaultMap == null) defaultMap = new LinkedHashMap<>();
 
-            // Create merged data structure
             Map<String, Object> mergedMap = new LinkedHashMap<>();
             Map<String, String> mergedComments = new LinkedHashMap<>();
 
-            // Merge the configurations
             mergeRecursive("", existingMap, defaultMap, mergedMap, existingData.comments, defaultData.comments, mergedComments);
 
             logger.fine("Merged configuration has " + mergedComments.size() + " comments");
 
-            // Generate the final YAML with preserved comments
             return generateYamlWithComments(mergedMap, mergedComments, defaultData.headerComments);
 
         } catch (Exception e) {
@@ -77,7 +72,6 @@ public class CommentPreservingYamlMigrator {
             Object existingValue = existing.get(key);
 
             if (defaultValue instanceof Map && existingValue instanceof Map) {
-                // Recursive merge for nested maps
                 Map<String, Object> nestedMerged = new LinkedHashMap<>();
                 merged.put(key, nestedMerged);
 
@@ -100,14 +94,12 @@ public class CommentPreservingYamlMigrator {
                 // Use existing value if present, otherwise use default
                 if (existingValue != null) {
                     merged.put(key, existingValue);
-                    // Preserve existing comment
                     String comment = existingComments.get(keyPath);
                     if (comment != null) {
                         mergedComments.put(keyPath, comment);
                     }
                 } else {
                     merged.put(key, defaultValue);
-                    // Use default comment for new field
                     String comment = defaultComments.get(keyPath);
                     if (comment != null) {
                         mergedComments.put(keyPath, comment);
@@ -124,7 +116,6 @@ public class CommentPreservingYamlMigrator {
             if (!defaults.containsKey(key)) {
                 String keyPath = path.isEmpty() ? key : path + "." + key;
                 merged.put(key, existing.get(key));
-                // Preserve comment for obsolete key
                 String comment = existingComments.get(keyPath);
                 if (comment != null) {
                     mergedComments.put(keyPath, comment);
@@ -157,13 +148,12 @@ public class CommentPreservingYamlMigrator {
             } else if (line.trim().contains(":") && !line.trim().startsWith("#") && !line.trim().startsWith("-")) {
                 foundFirstKey = true;
 
-                // This is a key line, associate pending comments with it
+                // Key line: attach pending comments to it
                 if (!pendingComments.isEmpty()) {
                     String keyPath = extractKeyPath(lines, lineIndex);
                     if (keyPath == null || keyPath.isEmpty()) {
                         keyPath = extractKey(line);
                     }
-                    // Combine all pending comments
                     String combinedComment = String.join(" ", pendingComments);
                     if (keyPath != null && !keyPath.isEmpty()) {
                         comments.put(keyPath, combinedComment);
@@ -182,26 +172,10 @@ public class CommentPreservingYamlMigrator {
         return new CommentedYamlData(comments, headerComments);
     }
 
-    private String findCommentTarget(String[] lines, int commentIndex) {
-        // Look for the next non-comment, non-empty line that contains a key
-        for (int i = commentIndex + 1; i < lines.length; i++) {
-            String line = lines[i].trim();
-            if (!line.startsWith("#") && line.contains(":")) {
-                // Skip lines that are just list items
-                if (line.startsWith("-")) {
-                    continue;
-                }
-                return extractKeyPath(lines, i);
-            }
-        }
-        return null;
-    }
-
     private String extractKeyPath(String[] lines, int lineIndex) {
         Stack<String> pathStack = new Stack<>();
         Stack<Integer> indentStack = new Stack<>();
 
-        // Build path up to this line
         for (int i = 0; i <= lineIndex; i++) {
             String line = lines[i];
             if (line.trim().contains(":") && !line.trim().startsWith("#")) {
@@ -244,7 +218,6 @@ public class CommentPreservingYamlMigrator {
         String trimmed = line.trim();
         if (trimmed.contains(":")) {
             String key = trimmed.split(":")[0].trim();
-            // Remove quotes if present
             if (key.startsWith("\"") && key.endsWith("\"")) {
                 key = key.substring(1, key.length() - 1);
             } else if (key.startsWith("'") && key.endsWith("'")) {
@@ -258,7 +231,6 @@ public class CommentPreservingYamlMigrator {
     private String generateYamlWithComments(Map<String, Object> data, Map<String, String> comments, List<String> headerComments) {
         StringBuilder result = new StringBuilder();
 
-        // Add header comments
         for (String comment : headerComments) {
             result.append("#").append(comment).append("\n");
         }
@@ -267,7 +239,6 @@ public class CommentPreservingYamlMigrator {
             result.append("\n");
         }
 
-        // Generate YAML with comments
         generateYamlSection(data, comments, result, "", 0);
 
         return result.toString();
@@ -283,7 +254,6 @@ public class CommentPreservingYamlMigrator {
             Object value = entry.getValue();
             String keyPath = pathPrefix.isEmpty() ? key : pathPrefix + "." + key;
 
-            // Add comment if exists
             String comment = comments.get(keyPath);
             if (comment != null && !comment.isEmpty()) {
                 result.append(indent).append("#").append(comment).append("\n");

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
@@ -56,7 +56,6 @@ public class ConfigMigrator {
         try {
             createBackup(configFile);
 
-            // Use comment-preserving migration
             String existingYaml = Files.readString(configFile.toPath(), StandardCharsets.UTF_8);
             String migratedYaml = getString(existingYaml);
 
@@ -80,7 +79,6 @@ public class ConfigMigrator {
             logger.severe("  Please report this error with the stack trace below:");
             e.printStackTrace();
 
-            // Attempt fallback to standard config
             logger.info("Attempting fallback to standard config merge...");
             try {
                 fallbackMigration(configFile, existingConfig);
@@ -98,11 +96,9 @@ public class ConfigMigrator {
         CommentPreservingYamlMigrator commentMigrator = new CommentPreservingYamlMigrator(logger);
         String migratedYaml = commentMigrator.mergeWithComments(existingYaml, defaultYaml);
 
-        // Ensure config-version is set
         if (!migratedYaml.contains("config-version:")) {
             migratedYaml = "config-version: " + CURRENT_CONFIG_VERSION + "\n" + migratedYaml;
         } else {
-            // Update existing config-version
             migratedYaml = migratedYaml.replaceFirst("config-version:\\s*\\d+", "config-version: " + CURRENT_CONFIG_VERSION);
         }
         return migratedYaml;

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
@@ -27,6 +27,12 @@ public class ConfigMigrator {
         this.logger = plugin.getLogger();
     }
 
+    /**
+     * Ensures the plugin's config.yml is at the current configuration version.
+     *
+     * If the config does not exist, a default is created. If the config exists but is outdated,
+     * it is updated to the current version.
+     */
     public void migrateConfig() {
         File dataFolder = plugin.getDataFolder();
         if (!dataFolder.exists() && !dataFolder.mkdirs()) {
@@ -90,6 +96,13 @@ public class ConfigMigrator {
         }
     }
 
+    /**
+     * Merges the existing YAML with the default YAML while preserving comments and ensures the correct config version.
+     *
+     * @param existingYaml the existing YAML content to merge with the default
+     * @return the merged YAML with the current config version
+     * @throws IOException if the default config cannot be read from the plugin jar
+     */
     private @NotNull String getString(String existingYaml) throws IOException {
         String defaultYaml = getDefaultConfigAsString();
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/SentryContextProvider.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/SentryContextProvider.java
@@ -16,6 +16,11 @@ public class SentryContextProvider {
         }
     }
 
+    /**
+     * Retrieves the server version.
+     *
+     * @return the server version, or "unknown" if unavailable
+     */
     public static String getServerVersion() {
         try {
             String version = Bukkit.getServer().getVersion();
@@ -25,6 +30,11 @@ public class SentryContextProvider {
         }
     }
 
+    /**
+     * Retrieves the Minecraft version.
+     *
+     * @return the Minecraft version, or {@code "unknown"} if unavailable
+     */
     public static String getMinecraftVersion() {
         try {
             String version = Bukkit.getMinecraftVersion();
@@ -35,7 +45,9 @@ public class SentryContextProvider {
     }
 
     /**
-     * Get Bukkit/Paper API version
+     * Retrieves the Bukkit/Paper API version.
+     *
+     * @return the Bukkit/Paper API version, or "unknown" if unavailable
      */
     public static String getBukkitVersion() {
         try {
@@ -46,6 +58,11 @@ public class SentryContextProvider {
         }
     }
 
+    /**
+     * Retrieves the Java version.
+     *
+     * @return the Java version string, or {@code "unknown"} if not available
+     */
     public static String getJavaVersion() {
         String version = System.getProperty("java.version");
         return version != null ? version : "unknown";

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/SentryContextProvider.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/SentryContextProvider.java
@@ -25,9 +25,6 @@ public class SentryContextProvider {
         }
     }
 
-    /**
-     * Get Minecraft version
-     */
     public static String getMinecraftVersion() {
         try {
             String version = Bukkit.getMinecraftVersion();
@@ -49,9 +46,6 @@ public class SentryContextProvider {
         }
     }
 
-    /**
-     * Get Java version
-     */
     public static String getJavaVersion() {
         String version = System.getProperty("java.version");
         return version != null ? version : "unknown";

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/StringUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/StringUtils.java
@@ -11,7 +11,7 @@ public class StringUtils {
      * @return -1 if version1 < version2, 0 if equal, 1 if version1 > version2
      */
     public static int compareSemVer(@NotNull String version1, @NotNull String version2) {
-        // If either version string does not match semantic versioning (e.g., "1.2.3"), return 0
+        // Non-semver strings are treated as equal
         if (!version1.matches("\\d+\\.\\d+\\.\\d+") || !version2.matches("\\d+\\.\\d+\\.\\d+")) {
             return 0;
         }
@@ -35,7 +35,6 @@ public class StringUtils {
 
     /**
      * Converts a legacy sound name (all uppercase with underscores) to the new format (lowercase with dots).
-     * Stateless utility for string conversion only.
      */
     public static String convertLegacySoundNameFormat(String soundName) {
         if (soundName != null && soundName.equals(soundName.toUpperCase(Locale.ROOT))) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/StringUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/StringUtils.java
@@ -6,9 +6,13 @@ import java.util.Locale;
 
 public class StringUtils {
     /**
-     * Compares two semantic version strings (e.g., "1.2.3").
+     * Compares two semantic version strings in the format major.minor.patch.
      *
-     * @return -1 if version1 < version2, 0 if equal, 1 if version1 > version2
+     * Strings that do not match the pattern X.Y.Z (where X, Y, Z are integers)
+     * are treated as equal.
+     *
+     * @return -1 if version1 is less than version2, 1 if version1 is greater,
+     *         0 if they are equal or either string is not a valid semantic version
      */
     public static int compareSemVer(@NotNull String version1, @NotNull String version2) {
         // Non-semver strings are treated as equal
@@ -34,7 +38,9 @@ public class StringUtils {
     }
 
     /**
-     * Converts a legacy sound name (all uppercase with underscores) to the new format (lowercase with dots).
+     * Converts legacy sound names from uppercase with underscores to lowercase with dots.
+     *
+     * Only converts if the input is entirely uppercase; returns the input unchanged otherwise.
      */
     public static String convertLegacySoundNameFormat(String soundName) {
         if (soundName != null && soundName.equals(soundName.toUpperCase(Locale.ROOT))) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
@@ -2,9 +2,10 @@ package dev.mja00.villagerLobotomizer.utils;
 
 import com.google.common.collect.ImmutableMap;
 import org.bukkit.Bukkit;
-
 import java.lang.reflect.Method;
 import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 public class VersionUtils   {
 
@@ -116,7 +117,7 @@ public class VersionUtils   {
         }
     }
 
-    private static String make(String in) {
+    private static @Nonnull String make(@Nonnull String in) {
         final char[] c = in.toCharArray();
         for (int i = 0; i < c.length; i++) {
             c[i] ^= 0x5A;

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
@@ -5,8 +5,7 @@ import org.bukkit.Bukkit;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import javax.annotation.Nonnull;
-
+import org.jetbrains.annotations.NotNull;
 public class VersionUtils   {
 
     private static final Map<String, SupportStatus> unsupportedServers;
@@ -117,7 +116,7 @@ public class VersionUtils   {
         }
     }
 
-    private static @Nonnull String make(@Nonnull String in) {
+    private static @NotNull String make(@NotNull String in) {
         final char[] c = in.toCharArray();
         for (int i = 0; i < c.length; i++) {
             c[i] ^= 0x5A;

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VersionUtils.java
@@ -111,11 +111,22 @@ public class VersionUtils   {
             this.supported = supported;
         }
 
+        /**
+         * Indicates whether this server configuration is supported.
+         *
+         * @return true if supported, false otherwise.
+         */
         public boolean isSupported() {
             return supported;
         }
     }
 
+    /**
+     * Applies an XOR cipher with 0x5A to each character.
+     *
+     * @param  in the string to transform
+     * @return the XOR-transformed string
+     */
     private static @NotNull String make(@NotNull String in) {
         final char[] c = in.toCharArray();
         for (int i = 0; i < c.length; i++) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
@@ -63,9 +63,10 @@ public class VillagerUtils {
     }
 
     /**
-     * Returns the set of workstation materials villagers can be employed at, derived from
-     * {@link #PROFESSION_TO_STATION} so it can never drift from the canonical profession map.
-     * The no-workstation professions (mapped to {@link Material#AIR}) are excluded.
+     * Collects all workstation materials from the profession-to-station mapping, excluding {@link Material#AIR}.
+     * Data is derived from {@link #PROFESSION_TO_STATION} to ensure consistency with the canonical profession map.
+     *
+     * @return an EnumSet of all workstation materials
      */
     public static java.util.EnumSet<Material> professionStationMaterials() {
         java.util.EnumSet<Material> stations = java.util.EnumSet.noneOf(Material.class);
@@ -78,10 +79,10 @@ public class VillagerUtils {
     }
 
     /**
-     * Check for a job site in a 1 block adjacent radius (including diagonals)
-     * This checks in a 3 block height box, for a total of 3x3x3 box
+     * Determines if a workstation block for the villager's profession exists within a 3×3×3 cube centered on the villager's location.
      *
-     * @param villager Villager entity the check is centered around
+     * @param villager the villager to check
+     * @return `true` if a matching workstation block is found, `false` otherwise
      */
     public static boolean isJobSiteNearby(Villager villager) {
         Material jobSite = PROFESSION_TO_STATION.get(villager.getProfession());
@@ -144,10 +145,7 @@ public class VillagerUtils {
     }
 
     /**
-     * Adds particles around a villager for visual effects
-     *
-     * @param particle The type of particle to spawn
-     * @param villager The villager to spawn particles around
+     * Spawns a burst of particles around the villager.
      */
     public static void addParticlesAroundSelf(Particle particle, Villager villager) {
         World world = villager.getWorld();
@@ -169,7 +167,9 @@ public class VillagerUtils {
     }
 
     /**
-     * Checks if a villager is allowed to restock based on the number of restocks today.
+     * Determines if a villager is allowed to restock.
+     *
+     * @return true if the villager has fewer than 2 restocks today, false otherwise
      */
     public static boolean allowedToRestock(Villager villager) {
         int numberOfRestocksToday = villager.getRestocksToday();
@@ -177,7 +177,12 @@ public class VillagerUtils {
     }
 
     /**
-     * Determines if a villager should restock, updating persistent data as needed.
+     * Determines whether a villager should restock, resetting the daily counter when a new day begins.
+     *
+     * @param villager the villager to check
+     * @param lastRestockCheckDayTimeKey the persistent data key for tracking the last full-time check
+     * @return {@code true} if the villager is allowed to restock today and has recipes requiring restocking,
+     *         {@code false} otherwise
      */
     public static boolean shouldRestock(Villager villager, NamespacedKey lastRestockCheckDayTimeKey) {
         PersistentDataContainer pdc = villager.getPersistentDataContainer();

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/VillagerUtils.java
@@ -58,9 +58,23 @@ public class VillagerUtils {
         soundMap.put(Villager.Profession.NITWIT, Sound.ENTITY_VILLAGER_CELEBRATE);
         soundMap.put(Villager.Profession.NONE, Sound.ENTITY_VILLAGER_CELEBRATE);
 
-        // One time registered map
         PROFESSION_TO_SOUND = Collections.unmodifiableMap(soundMap);
         PROFESSION_TO_STATION = Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Returns the set of workstation materials villagers can be employed at, derived from
+     * {@link #PROFESSION_TO_STATION} so it can never drift from the canonical profession map.
+     * The no-workstation professions (mapped to {@link Material#AIR}) are excluded.
+     */
+    public static java.util.EnumSet<Material> professionStationMaterials() {
+        java.util.EnumSet<Material> stations = java.util.EnumSet.noneOf(Material.class);
+        for (Material station : PROFESSION_TO_STATION.values()) {
+            if (station != Material.AIR) {
+                stations.add(station);
+            }
+        }
+        return stations;
     }
 
     /**
@@ -68,7 +82,6 @@ public class VillagerUtils {
      * This checks in a 3 block height box, for a total of 3x3x3 box
      *
      * @param villager Villager entity the check is centered around
-     * @return
      */
     public static boolean isJobSiteNearby(Villager villager) {
         Material jobSite = PROFESSION_TO_STATION.get(villager.getProfession());
@@ -142,62 +155,46 @@ public class VillagerUtils {
         BoundingBox boundingBox = villager.getBoundingBox();
         Random random = new Random();
 
-        // Spawn 5 particles around the villager
         for (int i = 0; i < 5; i++) {
             double d = random.nextGaussian() * 0.02;
             double d1 = random.nextGaussian() * 0.02;
             double d2 = random.nextGaussian() * 0.02;
-            // Get a vertical offset above the villager
             double randomY = villager.getY() + boundingBox.getHeight() * random.nextDouble();
             double xScale = (2.0 * random.nextDouble() - 1.0) * scale;
             double randomX = villager.getX() + boundingBox.getWidthX() * xScale;
             double zScale = (2.0 * random.nextDouble() - 1.0) * scale;
             double randomZ = villager.getZ() + boundingBox.getWidthZ() * zScale;
-            // Spawn the particle
             world.spawnParticle(particle, randomX, randomY, randomZ, 1, d, d1, d2, 0.0);
         }
     }
 
     /**
-     * Checks if a villager is allowed to restock based on restocks today and last restock game time.
+     * Checks if a villager is allowed to restock based on the number of restocks today.
      */
-    public static boolean allowedToRestock(Villager villager, NamespacedKey lastRestockFullTimeKey) {
+    public static boolean allowedToRestock(Villager villager) {
         int numberOfRestocksToday = villager.getRestocksToday();
-        // Allow up to 2 restocks per day (vanilla behavior)
-        // The cooldown between restocks is handled by the config's restock-interval (wall-clock based)
-        // rather than a hardcoded game-time check, which is problematic when doDaylightCycle is disabled
-        return numberOfRestocksToday != 2;
+        return numberOfRestocksToday < 2;
     }
 
     /**
      * Determines if a villager should restock, updating persistent data as needed.
      */
-    public static boolean shouldRestock(Villager villager, NamespacedKey lastRestockGameTimeKey, NamespacedKey lastRestockCheckDayTimeKey) {
+    public static boolean shouldRestock(Villager villager, NamespacedKey lastRestockCheckDayTimeKey) {
         PersistentDataContainer pdc = villager.getPersistentDataContainer();
         long lastRestockCheckDayTime = pdc.getOrDefault(lastRestockCheckDayTimeKey, org.bukkit.persistence.PersistentDataType.LONG, 0L);
         long fullTime = villager.getWorld().getFullTime();
-        
+
         // Check for new day using Full Time (absolute ticks) to avoid wrapping issues
         if (lastRestockCheckDayTime > 0L) {
             long lastDay = lastRestockCheckDayTime / 24000L;
             long currentDay = fullTime / 24000L;
             if (currentDay > lastDay) {
                 villager.setRestocksToday(0);
-                pdc.set(lastRestockGameTimeKey, org.bukkit.persistence.PersistentDataType.LONG, 0L);
             }
         }
-        
-        // Update the last check time to current full time
+
         pdc.set(lastRestockCheckDayTimeKey, org.bukkit.persistence.PersistentDataType.LONG, fullTime);
 
-        boolean allowed = allowedToRestock(villager, lastRestockGameTimeKey) && needsToRestock(villager);
-        
-        if (allowed) {
-            // Update last restock time to now, so the cooldown works for the next check
-            // Using getFullTime() (persistent) instead of getGameTime() (can reset)
-            pdc.set(lastRestockGameTimeKey, org.bukkit.persistence.PersistentDataType.LONG, fullTime);
-        }
-        
-        return allowed;
+        return allowedToRestock(villager) && needsToRestock(villager);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -56,6 +56,7 @@ check-roof: true
 create-debug-teams: false
 
 #Disable the update checker. You can disable this if you don't want to be notified about updates.
+#Note: this is only read when the plugin loads; changing it requires a server restart (a /lobotomy reload will not re-run the update check).
 disable-update-checker: false
 
 #Disable chunk forced Villager updating. This'll disable changes to blocks in a chunk from triggering Villagers in the chunk to be updated.

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -8,5 +8,26 @@ website: https://github.com/mja00/VillagerLobotimizer
 folia-supported: true
 permissions:
   lobotomy.command:
-    description: "Allows the use of the lobotomy command"
+    description: "Allows the use of all lobotomy commands"
+    default: op
+    children:
+      lobotomy.command.info: true
+      lobotomy.command.debug: true
+      lobotomy.command.wake: true
+      lobotomy.command.reload: true
+      lobotomy.command.config: true
+  lobotomy.command.info:
+    description: "Allows viewing villager statistics"
+    default: op
+  lobotomy.command.debug:
+    description: "Allows debugging villagers and toggling debug mode"
+    default: op
+  lobotomy.command.wake:
+    description: "Allows waking up lobotomized villagers"
+    default: op
+  lobotomy.command.reload:
+    description: "Allows reloading the plugin configuration"
+    default: op
+  lobotomy.command.config:
+    description: "Allows viewing and modifying config values"
     default: op

--- a/src/test/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicyTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicyTest.java
@@ -1,0 +1,244 @@
+package dev.mja00.villagerLobotomizer.policy;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VillagerActivityPolicyTest {
+
+    private static final BlockSnapshot AIR = new BlockSnapshot(Material.AIR, true, false);
+    private static final BlockSnapshot STONE = new BlockSnapshot(Material.STONE, false, true);
+    private static final BlockSnapshot WATER = new BlockSnapshot(Material.WATER, true, false);
+    private static final BlockSnapshot CARPET = new BlockSnapshot(Material.WHITE_CARPET, false, true);
+    private static final BlockSnapshot HONEY = new BlockSnapshot(Material.HONEY_BLOCK, false, true);
+    private static final BlockSnapshot DOOR = new BlockSnapshot(Material.OAK_DOOR, false, true);
+    private static final BlockSnapshot FENCE = new BlockSnapshot(Material.OAK_FENCE, false, true);
+
+    /** Minimal hand-built classifier — we control exactly which materials are "impassable". */
+    private static BlockClassifier classifier() {
+        return new BlockClassifier(
+                EnumSet.of(Material.STONE),                                    // impassableRegular
+                EnumSet.of(Material.OAK_FENCE),                                // impassableTall
+                EnumSet.of(Material.STONE, Material.WHITE_CARPET, Material.OAK_FENCE), // impassableAll
+                EnumSet.of(Material.WHEAT),                                    // cropBlocks
+                EnumSet.of(Material.OAK_DOOR),                                 // doorBlocks
+                EnumSet.of(Material.LECTERN));                                 // professionBlocks
+    }
+
+    /** A mutable grid of snapshots; any coordinate not set defaults to AIR. */
+    private static final class TestGrid implements BlockGrid {
+        private final Map<Long, BlockSnapshot> blocks = new HashMap<>();
+        private final Set<Long> unloadedColumns = new java.util.HashSet<>();
+
+        private static long key(int x, int y, int z) {
+            return (((long) x) & 0x3FFFFFF) | ((((long) z) & 0x3FFFFFF) << 26) | ((((long) y) & 0xFFF) << 52);
+        }
+
+        private static long col(int x, int z) {
+            return (((long) x) & 0x3FFFFFF) | ((((long) z) & 0x3FFFFFF) << 26);
+        }
+
+        TestGrid set(int x, int y, int z, BlockSnapshot snapshot) {
+            blocks.put(key(x, y, z), snapshot);
+            return this;
+        }
+
+        TestGrid unload(int x, int z) {
+            unloadedColumns.add(col(x, z));
+            return this;
+        }
+
+        @Override
+        public BlockSnapshot at(int x, int y, int z) {
+            if (unloadedColumns.contains(col(x, z))) {
+                return null;
+            }
+            return blocks.getOrDefault(key(x, y, z), AIR);
+        }
+    }
+
+    private VillagerActivityPolicy policy(boolean lobotomizePassengers, boolean onlyProfessions,
+                                          boolean onlyWithExperience, boolean checkRoof,
+                                          boolean ignoreStuckInDoors, boolean ignoreNonSolidBlocks,
+                                          Set<String> exemptNames) {
+        return new VillagerActivityPolicy(lobotomizePassengers, onlyProfessions, onlyWithExperience,
+                checkRoof, ignoreStuckInDoors, ignoreNonSolidBlocks, exemptNames, classifier());
+    }
+
+    private VillagerActivityPolicy defaultPolicy() {
+        return policy(false, false, false, false, false, false, Set.of());
+    }
+
+    private static VillagerState villager(String name, int x, int y, int z) {
+        return new VillagerState(name, false, false, false, false, 10, x, y, z);
+    }
+
+    /** Surround the four cardinal neighbours of (x,z) at feet level with STONE (a sealed box). */
+    private static TestGrid sealedBox(int x, int y, int z) {
+        return new TestGrid()
+                .set(x + 1, y, z, STONE)
+                .set(x - 1, y, z, STONE)
+                .set(x, y, z + 1, STONE)
+                .set(x, y, z - 1, STONE);
+    }
+
+    @Test
+    void openSpaceIsActive() {
+        // All neighbours default to AIR -> walkable -> active.
+        assertTrue(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), new TestGrid()));
+    }
+
+    @Test
+    void sealedBoxIsInactive() {
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void nobrainNameForcesInactiveEvenInOpenSpace() {
+        assertFalse(defaultPolicy().shouldBeActive(villager("mr nobrain", 0, 64, 0), new TestGrid()));
+    }
+
+    @Test
+    void nobrainNameTakesPrecedenceOverExemptName() {
+        // "nobrain" is checked before the exempt-name list, so a name matching both -> inactive.
+        VillagerActivityPolicy p = policy(false, false, false, false, false, false, Set.of("nobrain keepme"));
+        assertFalse(p.shouldBeActive(villager("nobrain keepme", 0, 64, 0), new TestGrid()));
+    }
+
+    @Test
+    void exemptNameForcesActiveEvenInSealedBox() {
+        VillagerActivityPolicy p = policy(false, false, false, false, false, false, Set.of("keepme"));
+        assertTrue(p.shouldBeActive(villager("keepme", 0, 64, 0), sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void swimmingForcesActiveInSealedBox() {
+        VillagerState v = new VillagerState("", true, false, false, false, 10, 0, 64, 0);
+        assertTrue(defaultPolicy().shouldBeActive(v, sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void waterAtFeetForcesActiveInSealedBox() {
+        TestGrid grid = sealedBox(0, 64, 0).set(0, 64, 0, WATER);
+        assertTrue(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void sleepingForcesActiveInSealedBox() {
+        VillagerState v = new VillagerState("", false, true, false, false, 10, 0, 64, 0);
+        assertTrue(defaultPolicy().shouldBeActive(v, sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void vehicleForcesInactiveOnlyWhenConfigured() {
+        VillagerState inVehicle = new VillagerState("", false, false, true, false, 10, 0, 64, 0);
+        // open space, but lobotomizePassengers + in a vehicle -> inactive
+        assertFalse(policy(true, false, false, false, false, false, Set.of())
+                .shouldBeActive(inVehicle, new TestGrid()));
+        // same state, feature off -> falls through to movement -> active
+        assertTrue(defaultPolicy().shouldBeActive(inVehicle, new TestGrid()));
+    }
+
+    @Test
+    void onlyProfessionsKeepsUnemployedActiveInSealedBox() {
+        VillagerState none = new VillagerState("", false, false, false, true, 10, 0, 64, 0);
+        assertTrue(policy(false, true, false, false, false, false, Set.of())
+                .shouldBeActive(none, sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void onlyWithExperienceKeepsZeroExpActiveInSealedBox() {
+        VillagerState zeroExp = new VillagerState("", false, false, false, false, 0, 0, 64, 0);
+        assertTrue(policy(false, false, true, false, false, false, Set.of())
+                .shouldBeActive(zeroExp, sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void carpetAsFloorOfNeighbourIsWalkable() {
+        // One neighbour has a carpet at feet level; carpets are a bypass -> walkable -> active.
+        TestGrid grid = sealedBox(0, 64, 0).set(1, 64, 0, CARPET);
+        assertTrue(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void doorNeighbourIsBypassOnlyWhenIgnoreStuckInDoors() {
+        // Box the villager in, but put a door on one neighbour's feet.
+        TestGrid grid = sealedBox(0, 64, 0).set(1, 64, 0, DOOR);
+        // doors not ignored -> door blocks (a door snapshot is not passable) -> still inactive
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+        // doors ignored -> door is a bypass -> walkable -> active
+        assertTrue(policy(false, false, false, false, true, false, Set.of())
+                .shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void checkRoofWithAirAboveForcesActive() {
+        // Sealed at feet level, but roof (y+2) is AIR and checkRoof is on -> active.
+        assertTrue(policy(false, false, false, true, false, false, Set.of())
+                .shouldBeActive(villager("", 0, 64, 0), sealedBox(0, 64, 0)));
+    }
+
+    @Test
+    void honeyBlockFloorActsAsRoofAndBlocksMovementOverTallBlocks() {
+        // A honey block under the villager sets hasRoof=true, which makes canMoveThrough also
+        // require the block UNDER each neighbour's feet to be passable. With fences (tall/impassable)
+        // under every neighbour, movement is blocked -> inactive.
+        TestGrid roofed = new TestGrid()
+                .set(0, 63, 0, HONEY)        // villager's floor -> hasRoof = true
+                .set(1, 63, 0, FENCE)
+                .set(-1, 63, 0, FENCE)
+                .set(0, 63, 1, FENCE)
+                .set(0, 63, -1, FENCE);
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), roofed));
+
+        // Control: no honey floor (and open roof) -> hasRoof = false -> under-feet ignored -> active.
+        TestGrid open = new TestGrid()
+                .set(1, 63, 0, FENCE)
+                .set(-1, 63, 0, FENCE)
+                .set(0, 63, 1, FENCE)
+                .set(0, 63, -1, FENCE);
+        assertTrue(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), open));
+    }
+
+    @Test
+    void unloadedNeighbourCountsAsNotMovable() {
+        // Box on three sides; the open side's chunk is unloaded -> not movable -> inactive.
+        TestGrid grid = new TestGrid()
+                .set(-1, 64, 0, STONE)
+                .set(0, 64, 1, STONE)
+                .set(0, 64, -1, STONE)
+                .unload(1, 0);
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void headHeightCarpetDoesNotBlockMovement() {
+        // A carpet at head height is passable (a bypass block) and must NOT trap the villager.
+        TestGrid grid = new TestGrid()
+                .set(1, 65, 0, CARPET)
+                .set(-1, 65, 0, CARPET)
+                .set(0, 65, 1, CARPET)
+                .set(0, 65, -1, CARPET);
+        assertTrue(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void headHeightSolidBlockBlocksMovement() {
+        // Mirror of headHeightCarpetDoesNotBlockMovement: a SOLID block at head height on every
+        // neighbour must still block movement, confirming the head check rejects solids (i.e. the
+        // carpet fix narrowed the check to carpets only and did not over-broaden it).
+        TestGrid grid = new TestGrid()
+                .set(1, 65, 0, STONE)
+                .set(-1, 65, 0, STONE)
+                .set(0, 65, 1, STONE)
+                .set(0, 65, -1, STONE);
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicyTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/policy/VillagerActivityPolicyTest.java
@@ -20,6 +20,10 @@ class VillagerActivityPolicyTest {
     private static final BlockSnapshot HONEY = new BlockSnapshot(Material.HONEY_BLOCK, false, true);
     private static final BlockSnapshot DOOR = new BlockSnapshot(Material.OAK_DOOR, false, true);
     private static final BlockSnapshot FENCE = new BlockSnapshot(Material.OAK_FENCE, false, true);
+    // Non-solid, non-passable, and not a bypass block (sign-like). Walkable only when ignoreNonSolidBlocks is on.
+    private static final BlockSnapshot NON_SOLID = new BlockSnapshot(Material.OAK_SIGN, false, false);
+    // A profession block that is also non-solid; must stay blocking even with ignoreNonSolidBlocks on.
+    private static final BlockSnapshot LECTERN = new BlockSnapshot(Material.LECTERN, false, false);
 
     /** Minimal hand-built classifier — we control exactly which materials are "impassable". */
     private static BlockClassifier classifier() {
@@ -175,6 +179,26 @@ class VillagerActivityPolicyTest {
         assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
         // doors ignored -> door is a bypass -> walkable -> active
         assertTrue(policy(false, false, false, false, true, false, Set.of())
+                .shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void nonSolidNeighbourIsWalkableOnlyWhenIgnoreNonSolidBlocks() {
+        // Box the villager in, but put a non-solid, non-passable, non-bypass block on one neighbour's feet.
+        TestGrid grid = sealedBox(0, 64, 0).set(1, 64, 0, NON_SOLID);
+        // non-solid blocks not ignored -> the block stays impassable -> still inactive
+        assertFalse(defaultPolicy().shouldBeActive(villager("", 0, 64, 0), grid));
+        // non-solid blocks ignored -> the block becomes walkable -> active
+        assertTrue(policy(false, false, false, false, false, true, Set.of())
+                .shouldBeActive(villager("", 0, 64, 0), grid));
+    }
+
+    @Test
+    void professionBlockStaysBlockingEvenWhenIgnoreNonSolidBlocks() {
+        // A non-solid profession block (lectern) is carved out of the ignoreNonSolidBlocks bypass,
+        // so it must keep blocking movement even with the feature on -> inactive.
+        TestGrid grid = sealedBox(0, 64, 0).set(1, 64, 0, LECTERN);
+        assertFalse(policy(false, false, false, false, false, true, Set.of())
                 .shouldBeActive(villager("", 0, 64, 0), grid));
     }
 


### PR DESCRIPTION
## Summary

Work from a multi-agent codebase review (`CODE_REVIEW.md`, included). Fixes the one Critical and 13 of the 16 Medium findings, then extracts the lobotomy-decision logic into a unit-testable `policy` package (Recommended Refactor #1 / finding #12). All changes build green; tests pass.

### Critical
- **Folia thread-ownership violation:** `scheduleChunkVillagerProcessing` enumerated chunk entities from the global region scheduler, throwing on Folia and flooding Sentry. Now dispatches entity access to the owning region via `getRegionScheduler().run(...)`.

### Correctness & lifecycle
- Restock cap used `!= 2` (re-enabled restocking at 3+); now `< 2`. Removed dead `lastRestockGameTime` tracking.
- `ignore-villagers-stuck-in-doors` could not be re-enabled via `/lobotomy reload` (static `DOOR_BLOCKS` was permanently cleared) — now a per-instance flag.
- Stale `isLobotomized` PDC marker now cleared even when persistence is toggled off.
- `enable-sentry` now applied on reload (init/close transitions); update-checker documented as load-time only.
- Closed villager-task scheduling races vs. removal/reload (`stateLock`-guarded) and added a `shuttingDown` guard to `processVillagerSafely`.
- `flush()` now wakes cross-region villagers via the entity scheduler on reload.
- Granular permission nodes registered in `paper-plugin.yml`.

### Performance
- Config intervals validated (zero/negative no longer crash the scheduler per villager).
- Precomputed crop materials (no per-check `BlockData` clone); cached `NamespacedKey`s; compute villager block coords once per check.

### Refactor (finding #12)
- New `dev.mja00.villagerLobotomizer.policy` package: `VillagerActivityPolicy` (pure decision logic) + `BlockSnapshot`/`BlockGrid`/`VillagerState`/`BlockClassifier`. `LobotomizeStorage` shed ~170 lines and now delegates via thin adapters.
- 18 unit tests covering the decision branches (previously untestable without a live server).
- Bug fix surfaced by the new tests: head-height carpets no longer wrongly trap villagers.

Behavior is preserved except two intentional, documented changes: `ignore-non-solid-blocks` is now read once at construction (consistent with other flags, re-read on reload), and the head-carpet fix.

Design/plan under `docs/superpowers/`.

## Test Plan
- [x] `./gradlew build` — BUILD SUCCESSFUL, all tests pass, no warnings
- [x] New `VillagerActivityPolicyTest` (18 tests) green; runs without a server
- [x] Smoke-test on a live **Folia** server in a busy trading hall (block break/place near tracked villagers; `/lobotomy reload`) — the Folia-specific fixes can't be exercised by unit tests
- [ ] Verify `/lobotomy reload` applies `enable-sentry` and `ignore-villagers-stuck-in-doors` toggles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added granular command permissions for info/debug/wake/reload/config.

* **Improvements**
  * Improved villager activity decisions with more accurate block-aware movement/pathing, roof/collision handling, and special-case rules.
  * Improved chunk evaluation safety and more reliable reload/shutdown behavior.
  * Updated update-checker documentation: changing the setting requires a server restart.

* **Bug Fixes**
  * Reduced scheduled-task leaks and tightened per-villager lifecycle handling.
  * More consistent trade refresh gating and lobotomized marker cleanup.

* **Tests**
  * Added unit tests for villager activity policy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->