### PR TITLE
feat: mockbukkit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,13 +29,25 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.6-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
     implementation("net.kyori:adventure-text-serializer-plain:4.22.0")
     implementation("org.bstats:bstats-bukkit:3.1.0")
     implementation("io.sentry:sentry:8.28.0")
     implementation("org.yaml:snakeyaml:2.2")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
+    // Plain paper-api for tests: MockBukkit ships no paper-api, and paperweight's NMS server is
+    // kept off the test classpath (see paperweight block) to avoid a duplicate server impl.
+    testImplementation("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    // MockBukkit 4.110 pins junit-jupiter-api 6.0.3, so align the whole platform via the BOM
+    testImplementation(platform("org.junit:junit-bom:6.0.3"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.110.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// Keep the paperweight server (NMS) artifact off the test classpath so MockBukkit's server
+// implementation is used instead. Safe because this plugin uses no NMS.
+paperweight {
+    addServerDependencyTo = configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).map { setOf(it) }
 }
 
 val targetJavaVersion = 21
@@ -113,11 +125,11 @@ tasks {
     }
 }
 
-// Planning on using API only available in 1.21.6 (and technically 1.21.5 but only the last like 10 builds)
-val supportedVersions = listOf("1.21.6-26.2")
+// Targeting 1.21.11+; support for 1.21.6-1.21.10 was dropped to align with MockBukkit's tested API
+val supportedVersions = listOf("1.21.11-26.2")
 
 // Modrinth requires discrete game versions rather than a range
-val modrinthGameVersions = listOf("1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11", "26.1", "26.1.1", "26.1.2", "26.2")
+val modrinthGameVersions = listOf("1.21.11", "26.1", "26.1.1", "26.1.2", "26.2")
 
 hangarPublish {
     publications.register("plugin") {

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -290,9 +290,7 @@ public class LobotomizeStorage {
         synchronized (this.stateLock) {
             ScheduledTask task = this.villagerTasks.remove(villager.getUniqueId());
             this.villagerTaskIntervals.remove(villager.getUniqueId());
-            if (task != null && !task.isCancelled()) {
-                task.cancel();
-            }
+            this.safeCancel(task);
             wasActive = this.activeVillagers.remove(villager);
             wasInactive = this.inactiveVillagers.remove(villager);
         }
@@ -343,6 +341,23 @@ public class LobotomizeStorage {
     }
 
     /**
+     * Cancels a scheduled task, swallowing any scheduler error. Cancellation failure is harmless:
+     * shuttingDown and the per-villager guards already neuter task bodies, so a surviving task no-ops.
+     */
+    private void safeCancel(ScheduledTask task) {
+        if (task == null) {
+            return;
+        }
+        try {
+            task.cancel();
+        } catch (Throwable t) {
+            if (this.plugin.isDebugging()) {
+                this.logger.fine("Failed to cancel scheduled task: " + t.getMessage());
+            }
+        }
+    }
+
+    /**
      * Stops tracking all villagers, cancels their scheduled tasks, and restores their activity state.
      * 
      * @param reloading {@code true} when the plugin remains enabled (such as during a config reload).
@@ -355,12 +370,8 @@ public class LobotomizeStorage {
         // Prevent new tasks from being scheduled past this point
         this.shuttingDown = true;
 
-        if (this.chunkProcessingTask != null && !this.chunkProcessingTask.isCancelled()) {
-            this.chunkProcessingTask.cancel();
-        }
-        if (this.watchdogTask != null && !this.watchdogTask.isCancelled()) {
-            this.watchdogTask.cancel();
-        }
+        this.safeCancel(this.chunkProcessingTask);
+        this.safeCancel(this.watchdogTask);
 
         // Wake all villagers before shutdown so they aren't left lobotomized forever if the plugin is removed
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
@@ -369,9 +380,7 @@ public class LobotomizeStorage {
         List<Villager> toFlush;
         synchronized (this.stateLock) {
             for (ScheduledTask task : this.villagerTasks.values()) {
-                if (task != null && !task.isCancelled()) {
-                    task.cancel();
-                }
+                this.safeCancel(task);
             }
             this.villagerTasks.clear();
             this.villagerTaskIntervals.clear();
@@ -457,9 +466,7 @@ public class LobotomizeStorage {
             if (!villager.isValid() || villager.isDead()) {
                 ScheduledTask task = this.villagerTasks.remove(villager.getUniqueId());
                 this.villagerTaskIntervals.remove(villager.getUniqueId());
-                if (task != null && !task.isCancelled()) {
-                    task.cancel();
-                }
+                this.safeCancel(task);
                 untrack(villager);
                 return;
             }

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -81,12 +81,13 @@ public class VillagerLobotomizer extends JavaPlugin {
         this.disableChunkVillagerUpdate = this.getConfig().getBoolean("disable-chunk-villager-updates");
         boolean createDebuggingTeams = this.getConfig().getBoolean("create-debug-teams", false);
 
-        // Metrics must never take down plugin enable; bStats also throws when running unrelocated (tests).
+        // Metrics must never take down plugin enable; bStats throws IllegalStateException when running
+        // unrelocated (tests) and a LinkageError if shaded wrong. Don't catch fatal Errors like OOM.
         try {
             Metrics metrics = new Metrics(this, 25704);
             this.setupMetrics(metrics);
-        } catch (Throwable t) {
-            this.getLogger().warning("Failed to initialize metrics: " + t.getMessage());
+        } catch (Exception | LinkageError e) {
+            this.getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize metrics", e);
         }
 
         // Check to see if plugman (or its fork Plugmanx) is installed. If so send a warning.

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-public final class VillagerLobotomizer extends JavaPlugin {
+public class VillagerLobotomizer extends JavaPlugin {
     private boolean debugging = false;
     private boolean chunkDebugging = false;
     private LobotomizeStorage storage;
@@ -81,9 +81,13 @@ public final class VillagerLobotomizer extends JavaPlugin {
         this.disableChunkVillagerUpdate = this.getConfig().getBoolean("disable-chunk-villager-updates");
         boolean createDebuggingTeams = this.getConfig().getBoolean("create-debug-teams", false);
 
-        Metrics metrics = new Metrics(this, 25704);
-
-        this.setupMetrics(metrics);
+        // Metrics must never take down plugin enable; bStats also throws when running unrelocated (tests).
+        try {
+            Metrics metrics = new Metrics(this, 25704);
+            this.setupMetrics(metrics);
+        } catch (Throwable t) {
+            this.getLogger().warning("Failed to initialize metrics: " + t.getMessage());
+        }
 
         // Check to see if plugman (or its fork Plugmanx) is installed. If so send a warning.
         PluginManager pluginManager = this.getServer().getPluginManager();

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,7 +1,7 @@
 name: VillagerLobotimizer
 version: '${version}'
 main: dev.mja00.villagerLobotomizer.VillagerLobotomizer
-api-version: '1.21.6'
+api-version: '1.21.11'
 authors: [ mja00, DereC4 ]
 description: A plugin that turns off Villager's brains when they're stuck in a trading hall.
 website: https://github.com/mja00/VillagerLobotimizer

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: VillagerLobotimizer
 version: '${version}'
 main: dev.mja00.villagerLobotomizer.VillagerLobotomizer
-api-version: '1.21.6'
+api-version: '1.21.11'
 authors: [ mja00, DereC4 ]
 description: A plugin that turns off Villager's brains when they're stuck in a trading hall.
 website: https://github.com/mja00/VillagerLobotimizer

--- a/src/test/java/dev/mja00/villagerLobotomizer/MockBukkitTestBase.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/MockBukkitTestBase.java
@@ -1,0 +1,25 @@
+package dev.mja00.villagerLobotomizer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+/**
+ * Base for tests that need a live (mocked) Bukkit server. Sets up and tears down a fresh
+ * {@link ServerMock} per test so registries and entities are available without a real server.
+ */
+public abstract class MockBukkitTestBase {
+
+    protected ServerMock server;
+
+    @BeforeEach
+    void mockServer() {
+        server = MockBukkit.mock();
+    }
+
+    @AfterEach
+    void unmockServer() {
+        MockBukkit.unmock();
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
@@ -1,0 +1,67 @@
+package dev.mja00.villagerLobotomizer.listeners;
+
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import dev.mja00.villagerLobotomizer.MockBukkitTestBase;
+import dev.mja00.villagerLobotomizer.VillagerLobotomizer;
+import org.bukkit.Location;
+import org.bukkit.entity.Villager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the event wiring in {@link EntityListener}: firing the Paper entity
+ * lifecycle events through the registered listener should add/remove villagers from storage.
+ */
+class EntityListenerTest extends MockBukkitTestBase {
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+
+    @BeforeEach
+    void loadPlugin() {
+        plugin = MockBukkit.load(VillagerLobotomizer.class);
+        world = server.addSimpleWorld("test");
+    }
+
+    private boolean isTracked(Villager villager) {
+        return plugin.getStorage().getActive().contains(villager)
+                || plugin.getStorage().getLobotomized().contains(villager);
+    }
+
+    @Test
+    void addEventTracksVillagerAsActive() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+
+        server.getPluginManager().callEvent(new EntityAddToWorldEvent(villager, world));
+
+        assertTrue(plugin.getStorage().getActive().contains(villager),
+                "a freshly added villager should be tracked as active");
+    }
+
+    @Test
+    void removeEventUntracksVillager() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        server.getPluginManager().callEvent(new EntityAddToWorldEvent(villager, world));
+        assertTrue(isTracked(villager), "precondition: villager is tracked after add");
+
+        server.getPluginManager().callEvent(new EntityRemoveFromWorldEvent(villager, world));
+
+        assertFalse(isTracked(villager), "a removed villager should no longer be tracked");
+    }
+
+    @Test
+    void constructorScanTracksExistingVillagers() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+
+        // A fresh listener scans loaded worlds and registers existing villagers
+        new EntityListener(plugin);
+
+        assertTrue(isTracked(villager), "existing villagers should be picked up by the constructor scan");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
@@ -59,6 +59,11 @@ class EntityListenerTest extends MockBukkitTestBase {
     void constructorScanTracksExistingVillagers() {
         Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
 
+        // Untrack first so the constructor scan is the only thing that can re-track it; this holds
+        // whether or not spawning auto-fired an add event through the already-registered listener.
+        plugin.getStorage().removeVillager(villager);
+        assertFalse(isTracked(villager), "precondition: villager is untracked before the scan");
+
         // A fresh listener scans loaded worlds and registers existing villagers
         new EntityListener(plugin);
 

--- a/src/test/java/dev/mja00/villagerLobotomizer/utils/SentryContextProviderRealPathTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/utils/SentryContextProviderRealPathTest.java
@@ -1,0 +1,36 @@
+package dev.mja00.villagerLobotomizer.utils;
+
+import dev.mja00.villagerLobotomizer.MockBukkitTestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Exercises the real (Bukkit-available) path of {@link SentryContextProvider}. The existing
+ * {@code SentryContextProviderTest} covers the no-Bukkit fallback; here a mocked server is active,
+ * so the provider should return actual values rather than the "unknown" fallback.
+ */
+class SentryContextProviderRealPathTest extends MockBukkitTestBase {
+
+    @Test
+    void serverBrandReflectsRunningServer() {
+        String brand = SentryContextProvider.getServerBrand();
+        assertNotNull(brand);
+        assertNotEquals("unknown", brand, "with a mocked server present, the real brand should resolve");
+    }
+
+    @Test
+    void minecraftVersionResolvesFromServer() {
+        String version = SentryContextProvider.getMinecraftVersion();
+        assertNotNull(version);
+        assertNotEquals("unknown", version, "minecraft version should resolve from the mocked server");
+    }
+
+    @Test
+    void bukkitVersionResolvesFromServer() {
+        String version = SentryContextProvider.getBukkitVersion();
+        assertNotNull(version);
+        assertNotEquals("unknown", version, "bukkit/api version should resolve from the mocked server");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/utils/VillagerUtilsTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/utils/VillagerUtilsTest.java
@@ -1,0 +1,108 @@
+package dev.mja00.villagerLobotomizer.utils;
+
+import dev.mja00.villagerLobotomizer.MockBukkitTestBase;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VillagerUtilsTest extends MockBukkitTestBase {
+
+    private static final NamespacedKey LAST_RESTOCK_KEY = NamespacedKey.fromString("vltest:last_restock_check");
+
+    private Villager spawnVillager() {
+        WorldMock world = server.addSimpleWorld("test");
+        return world.spawn(new Location(world, 0, 64, 0), Villager.class);
+    }
+
+    @Test
+    void getVillagerLevelMapsExperienceToLevelAtBoundaries() {
+        Villager villager = spawnVillager();
+        int[][] cases = {
+                {0, 1}, {9, 1}, {10, 2}, {69, 2}, {70, 3}, {149, 3}, {150, 4}, {249, 4}, {250, 5}
+        };
+        for (int[] c : cases) {
+            villager.setVillagerExperience(c[0]);
+            assertEquals(c[1], VillagerUtils.getVillagerLevel(villager),
+                    "experience " + c[0] + " should be level " + c[1]);
+        }
+    }
+
+    @Test
+    void professionStationMaterialsExcludesAirAndCoversEveryStation() {
+        var stations = VillagerUtils.professionStationMaterials();
+        assertFalse(stations.contains(Material.AIR), "AIR must not be a station material");
+        // Every non-AIR station in the canonical map must be present
+        for (Material station : VillagerUtils.PROFESSION_TO_STATION.values()) {
+            if (station != Material.AIR) {
+                assertTrue(stations.contains(station), station + " should be in the station set");
+            }
+        }
+        // Sound map must cover the same professions as the station map
+        assertEquals(VillagerUtils.PROFESSION_TO_STATION.keySet(), VillagerUtils.PROFESSION_TO_SOUND.keySet(),
+                "station and sound maps should cover the same professions");
+    }
+
+    @Test
+    void needsToRestockTrueOnlyWhenATradeHasBeenUsed() {
+        Villager villager = spawnVillager();
+        MerchantRecipe unused = new MerchantRecipe(new ItemStack(Material.EMERALD), 16);
+        villager.setRecipes(List.of(unused));
+        assertFalse(VillagerUtils.needsToRestock(villager), "no uses means no restock needed");
+
+        MerchantRecipe used = new MerchantRecipe(new ItemStack(Material.EMERALD), 16);
+        used.setUses(3);
+        villager.setRecipes(List.of(used));
+        assertTrue(VillagerUtils.needsToRestock(villager), "a used trade means restock needed");
+    }
+
+    @Test
+    void isJobSiteNearbyDetectsMatchingStationWithinBox() {
+        Villager villager = spawnVillager();
+        villager.setProfession(Villager.Profession.FARMER); // station = COMPOSTER
+        WorldMock world = (WorldMock) villager.getWorld();
+
+        // No station nearby yet
+        assertFalse(VillagerUtils.isJobSiteNearby(villager));
+
+        // Place the composter one block away (within the 3x3x3 box)
+        world.getBlockAt(1, 64, 0).setType(Material.COMPOSTER);
+        assertTrue(VillagerUtils.isJobSiteNearby(villager));
+    }
+
+    @Test
+    void isJobSiteNearbyFalseForProfessionWithoutStation() {
+        Villager villager = spawnVillager();
+        villager.setProfession(Villager.Profession.NONE); // station = AIR
+        assertFalse(VillagerUtils.isJobSiteNearby(villager), "professions mapped to AIR have no job site");
+    }
+
+    @Test
+    void shouldRestockResetsDailyCounterOnNewDay() {
+        Villager villager = spawnVillager();
+        WorldMock world = (WorldMock) villager.getWorld();
+
+        // Record a check during day 0, with one restock already used today
+        villager.getPersistentDataContainer().set(LAST_RESTOCK_KEY, PersistentDataType.LONG, 100L);
+        villager.setRestocksToday(1);
+
+        // Advance to day 1 (fullTime / 24000 increments)
+        world.setFullTime(24_000L + 50L);
+        VillagerUtils.shouldRestock(villager, LAST_RESTOCK_KEY);
+
+        assertEquals(0, villager.getRestocksToday(), "crossing a day boundary resets the restock counter");
+        assertEquals(24_050L, villager.getPersistentDataContainer()
+                .getOrDefault(LAST_RESTOCK_KEY, PersistentDataType.LONG, 0L), "PDC updated to current full time");
+    }
+}

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1,0 +1,72 @@
+#Configuration version - DO NOT MODIFY MANUALLY
+config-version: 6
+
+#List of names that will always keep villagers active (case-insensitive)
+always-active-names:
+  - "alwaysbrain"
+
+#Interval between trapped checks, in ticks, for active villagers
+check-interval: 150
+
+#Interval between trapped checks, in ticks, for inactive villagers
+inactive-check-interval: 150
+
+#Interval between villager trade restocks, in milliseconds
+restock-interval: 540000
+
+#Range (in milliseconds) before restock-interval to start random restock checks. If set to 0, restocking is not randomized. If equal to or greater than restock-interval, restock will always occur.
+restock-random-range: 0
+
+#Whether to only lobotomize villagers with jobs
+only-lobotomize-villagers-with-professions: false
+
+#Whether to only lobotomize villagers that have been traded at least once
+only-lobotomize-villagers-with-experience: false
+
+#Whether to lobotomize villagers in boats/minecarts. Does not apply to villagers riding on non-vehicle entities like horses.
+always-lobotomize-villagers-in-vehicles: false
+
+#Whether to make lobotomized villagers silent. When enabled, villagers will be muted when their AI is disabled.
+silent-lobotomized-villagers: false
+
+#The sound to play when a villager restocks. Leave empty ("") for default sounds.
+restock-sound: ""
+
+#The sound played when a villager is leveled up. Leave empty ("") for no sound.
+level-up-sound: "entity.villager.celebrate"
+
+#Debug mode. Prints debug messages to the console.
+debug: false
+
+#Chunk debug mode. Prints debug messages related to chunks
+chunk-debug: false
+
+#To ignore villagers stuck in doors, set this to true.
+ignore-villagers-stuck-in-doors: false
+
+#To not lobotomize villagers surrounded by non-solid blocks, set this to true.
+ignore-non-solid-blocks: false
+
+#To check if there is a roof above a villager before lobotomizing, set this to true
+check-roof: true
+
+#Create teams for debugging purposes.
+create-debug-teams: false
+
+#Disable the update checker. Kept true for tests to avoid the onEnable HTTP call.
+disable-update-checker: true
+
+#Disable chunk forced Villager updating.
+disable-chunk-villager-updates: false
+
+#Prevent trading with unlobotomized villagers.
+prevent-trading-with-unlobotomized-villagers: false
+
+#Message that is sent to players when they try to trade with an unlobotomized villager. Supports MiniMessage.
+unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>"
+
+#Persist lobotomized state across chunk unloads.
+persist-lobotomized-state: true
+
+#Sentry disabled for tests to avoid network init during MockBukkit.load().
+enable-sentry: false


### PR DESCRIPTION
Adds mockbukkit to our unit tests. Also bumps minimum api version to 1.21.11. Some guards had to be added due to poor Folia support but I plan on PRing some fixes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded automated test coverage for villager tracking and utility behavior.
* **Bug Fixes**
  * Improved task cancellation/cleanup to be more resilient during removals and shutdown/flush operations.
  * Made analytics/metrics startup failures non-fatal, so the plugin continues enabling.
* **Compatibility / Updates**
  * Updated Paper and Bukkit API target to 1.21.11.
  * Refined supported Minecraft versions/publishing targets to align with the newer release line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->