### PR TITLE
feat: preserve lobotomized villager state across shutdowns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,8 @@ name: Build Test
 
 on:
   push:
-  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,10 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 
 ### PDC Keys
 - `lastRestock` (LONG): Last trade refresh timestamp
-- `isLobotomized` (BYTE): Persistence marker (when `persist-lobotomized-state: true`)
+- `isLobotomized` (STRING): Installation-generation persistence marker (when `persist-lobotomized-state: true`); legacy BYTE markers are migrated on load
 - `lastRestockCheckDayTime` (LONG): Full game time (absolute ticks) at last restock check; used for day-rollover detection
+
+`state.yml` stores the current marker generation and legacy-marker migration state. Uninstall cleanup rotates the generation so markers belonging to unloaded entities are ignored after a later reinstall.
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 
 **VillagerUtils.java** - Maps: `PROFESSION_TO_STATION`, `PROFESSION_TO_SOUND`. Methods: `isJobSiteNearby()` (3x3x3 box), `shouldRestock()` (PDC+day-time logic)
 
-### Config (read in constructors)
-`check-interval`, `inactive-check-interval`, `restock-interval`, `restock-random-range`, `restock-sound`, `level-up-sound`, `debug`, `chunk-debug`, `create-debug-teams` (Folia-incompatible), `check-roof`, `ignore-non-solid-blocks`, `disable-chunk-villager-updates`, `persist-lobotomized-state`
+### Config
+`check-interval`, `inactive-check-interval`, `restock-interval`, `restock-random-range`, `restock-sound`, `level-up-sound`, `debug`, `chunk-debug`, `create-debug-teams` (Folia-incompatible), `check-roof`, `ignore-non-solid-blocks`, `disable-chunk-villager-updates`, `persist-lobotomized-state`. Most behavior config is captured by constructors and refreshed on reload. `uninstall` is read on disable so opt-in villager/PDC cleanup can be enabled immediately before shutdown.
 
 ### PDC Keys
 - `lastRestock` (LONG): Last trade refresh timestamp

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Minecraft Paper plugin that improves server performance by turning off village
 
 ```yaml
 #Configuration version - DO NOT MODIFY MANUALLY
-config-version: 4
+config-version: 7
 
 #List of names that will always keep villagers active (case-insensitive)
 always-active-names:
@@ -102,6 +102,10 @@ prevent-trading-with-unlobotomized-villagers: false
 #Persist lobotomized state across chunk unloads. When enabled, villagers that are lobotomized will remain lobotomized when their chunk is unloaded and reloaded.
 #This prevents lag spikes from villagers needing to be re-evaluated and re-lobotomized after chunk loads.
 persist-lobotomized-state: true
+
+#Set this to true before permanently uninstalling the plugin. On disable, all tracked villagers will be woken and their persistent lobotomy markers removed.
+#Keep this false during normal operation so lobotomized state survives server restarts.
+uninstall: false
 
 #Enable Sentry error tracking to help developers identify and fix bugs. See "Privacy & Telemetry" section below for details.
 enable-sentry: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.mja00"
-version = "1.15.2"
+version = "1.15.3"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     java
     id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
-    id("xyz.jpenilla.run-paper") version "3.0.+"
-    id("io.papermc.hangar-publish-plugin") version "0.1.+"
-    id("com.gradleup.shadow") version "9.3.+"
-    id("com.modrinth.minotaur") version "2.+"
+    id("xyz.jpenilla.run-paper") version "3.0.2"
+    id("io.papermc.hangar-publish-plugin") version "0.1.4"
+    id("com.gradleup.shadow") version "9.3.2"
+    id("com.modrinth.minotaur") version "2.9.0"
 }
 
 group = "dev.mja00"

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -265,6 +265,13 @@ public class LobotomizeStorage {
                 this.logger.info("[Debug] Re-lobotomized villager " + villager + " (" + villager.getUniqueId() + ") on chunk load");
             }
         } else {
+            // Repair markerless NoAI left by interrupted or older shutdowns before tracking as active.
+            if (!villager.isAware()) {
+                villager.setAware(true);
+                if (this.silentLobotomizedVillagers) {
+                    villager.setSilent(false);
+                }
+            }
             setActive(villager);
 
             if (this.plugin.isDebugging()) {
@@ -297,13 +304,22 @@ public class LobotomizeStorage {
         boolean removed = wasActive || wasInactive;
 
         if (wasInactive) {
-            // Use Paper's EntityScheduler for thread safety
-            villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((scheduledTask) -> {
-                villager.setAware(true);
-                if (this.silentLobotomizedVillagers) {
-                    villager.setSilent(false);
+            // EntityRemoveFromWorldEvent is delivered on the owning thread, so restore immediately
+            // before the entity scheduler can retire. Keep the marker for immediate restoration if
+            // the entity is later loaded while the plugin is still installed.
+            try {
+                restoreVillagerActivity(villager);
+            } catch (IllegalStateException e) {
+                try {
+                    villager.getScheduler().run(this.plugin,
+                            SentryTaskWrapper.wrap((scheduledTask) -> restoreVillagerActivity(villager)), null);
+                } catch (Exception schedulerException) {
+                    if (this.plugin.isDebugging()) {
+                        this.logger.warning("Failed to restore villager " + villager.getUniqueId()
+                                + " while removing it from tracking: " + schedulerException.getMessage());
+                    }
                 }
-            }), null);
+            }
         }
 
         if (this.plugin.isDebugging()) {
@@ -334,8 +350,27 @@ public class LobotomizeStorage {
     }
 
     /**
+     * Restores an inactive villager before its chunk is serialized and unloaded. The PDC marker is
+     * intentionally retained so a future chunk load can immediately restore the lobotomized state.
+     *
+     * @param villager the villager whose chunk is about to unload
+     */
+    public void prepareVillagerForUnload(@NotNull Villager villager) {
+        if (!this.inactiveVillagers.contains(villager)) {
+            return;
+        }
+
+        try {
+            restoreVillagerActivity(villager);
+        } catch (IllegalStateException e) {
+            this.logger.warning("Failed to restore villager " + villager.getUniqueId()
+                    + " before chunk unload: " + e.getMessage());
+        }
+    }
+
+    /**
      * Flushes all tracked villagers from storage and stops their processing tasks during shutdown.
-     * Villager state is only restored when {@code uninstall} is enabled in the configuration.
+     * Villager state is restored when persistence is disabled or {@code uninstall} is enabled.
      */
     public final void flush() {
         flush(false);
@@ -365,7 +400,7 @@ public class LobotomizeStorage {
      * @param reloading {@code true} when the plugin remains enabled (such as during a config reload).
      *                  Wake operations are dispatched via each villager's {@code EntityScheduler}, 
      *                  ensuring safe cross-region (Folia) execution. {@code false} during plugin shutdown,
-     *                  where villager state is preserved unless {@code uninstall} is enabled.
+     *                  where state is only preserved when persistent lobotomized state remains enabled.
      */
     public final void flush(boolean reloading) {
         // Prevent new tasks from being scheduled past this point
@@ -377,7 +412,13 @@ public class LobotomizeStorage {
         // Reloads must restore state before the replacement storage rescans villagers. During a normal
         // shutdown, preserve the state and PDC marker so villagers can be restored immediately on startup.
         // Administrators explicitly opt into cleanup before permanently removing the plugin.
-        boolean cleanupVillagerState = reloading || this.plugin.getConfig().getBoolean("uninstall", false);
+        boolean persistenceConfiguredAtShutdown = this.plugin.getConfig()
+                .getBoolean("persist-lobotomized-state", this.persistLobotomizedState);
+        boolean canPreserveLobotomizedState = this.persistLobotomizedState
+                && persistenceConfiguredAtShutdown;
+        boolean cleanupVillagerState = reloading
+                || this.plugin.getConfig().getBoolean("uninstall", false)
+                || !canPreserveLobotomizedState;
 
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
         // Cancel and clear per-villager tasks under the same lock that scheduleVillagerTask holds, so a
@@ -456,11 +497,18 @@ public class LobotomizeStorage {
      * that owns the entity (call directly only when already on it, otherwise via its EntityScheduler).
      */
     private void wakeVillager(@NotNull Villager villager) {
+        restoreVillagerActivity(villager);
+        clearLobotomizedMarker(villager);
+    }
+
+    /**
+     * Restores vanilla activity without changing the persistent lobotomy marker.
+     */
+    private void restoreVillagerActivity(@NotNull Villager villager) {
         villager.setAware(true);
         if (this.silentLobotomizedVillagers) {
             villager.setSilent(false);
         }
-        clearLobotomizedMarker(villager);
     }
     
     
@@ -548,12 +596,14 @@ public class LobotomizeStorage {
             // Clear any stale marker whenever the villager should be active, not just on transition,
             // so a marker left by a prior persist-enabled run can't re-lobotomize it after a config flip.
             clearLobotomizedMarker(villager);
-            if (!active) {
-                // Already running on entity thread, safe to modify villager
+            if (!villager.isAware()) {
                 villager.setAware(true);
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(false);
                 }
+            }
+            if (!active) {
+                // Already running on entity thread, safe to modify villager
                 setActive(villager);
                 if (this.plugin.isDebugging()) {
                     this.logger.info("[Debug] Villager " + villager + " (" + villager.getUniqueId() + ") is now active");

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -249,8 +249,7 @@ public class LobotomizeStorage {
 
         boolean wasLobotomized = false;
         if (this.persistLobotomizedState) {
-            PersistentDataContainer pdc = villager.getPersistentDataContainer();
-            wasLobotomized = pdc.has(this.lobotomizedKey, PersistentDataType.BYTE);
+            wasLobotomized = hasCurrentLobotomizedMarker(villager);
         }
 
         if (wasLobotomized) {
@@ -341,12 +340,50 @@ public class LobotomizeStorage {
         // previously-enabled config must not survive to re-lobotomize a woken villager if the feature
         // is toggled back on. has() keeps this cheap when there is nothing to remove.
         PersistentDataContainer pdc = villager.getPersistentDataContainer();
-        if (pdc.has(this.lobotomizedKey, PersistentDataType.BYTE)) {
+        if (pdc.has(this.lobotomizedKey, PersistentDataType.STRING)
+                || pdc.has(this.lobotomizedKey, PersistentDataType.BYTE)) {
             pdc.remove(this.lobotomizedKey);
             if (this.plugin.isDebugging()) {
                 this.logger.info("[Debug] Removed persistent lobotomized marker from " + villager.getUniqueId());
             }
         }
+    }
+
+    /**
+     * Accepts markers from the current installation generation and migrates legacy byte markers.
+     * Markers invalidated by an uninstall are removed instead of being honored on reinstall.
+     */
+    private boolean hasCurrentLobotomizedMarker(@NotNull Villager villager) {
+        PersistentDataContainer pdc = villager.getPersistentDataContainer();
+        String markerGeneration = pdc.get(this.lobotomizedKey, PersistentDataType.STRING);
+        if (markerGeneration != null) {
+            if (markerGeneration.equals(this.plugin.getLobotomyGeneration())) {
+                return true;
+            }
+            pdc.remove(this.lobotomizedKey);
+            if (this.plugin.isDebugging()) {
+                this.logger.info("[Debug] Removed stale lobotomized marker from " + villager.getUniqueId());
+            }
+            return false;
+        }
+
+        if (!pdc.has(this.lobotomizedKey, PersistentDataType.BYTE)) {
+            return false;
+        }
+        if (this.plugin.acceptsLegacyLobotomyMarkers()) {
+            setLobotomizedMarker(villager);
+            return true;
+        }
+
+        pdc.remove(this.lobotomizedKey);
+        return false;
+    }
+
+    private void setLobotomizedMarker(@NotNull Villager villager) {
+        villager.getPersistentDataContainer().set(
+                this.lobotomizedKey,
+                PersistentDataType.STRING,
+                this.plugin.getLobotomyGeneration());
     }
 
     /**
@@ -625,7 +662,7 @@ public class LobotomizeStorage {
                     villager.setSilent(true);
                 }
                 if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                    setLobotomizedMarker(villager);
                     if (this.plugin.isDebugging()) {
                         this.logger.info("[Debug] Set persistent lobotomized marker for " + villager.getUniqueId());
                     }
@@ -644,7 +681,7 @@ public class LobotomizeStorage {
                     villager.setSilent(true);
                 }
                 if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                    setLobotomizedMarker(villager);
                 }
             }
             if (this.plugin.isDebugging() && !this.plugin.isFolia() && this.plugin.getInactiveVillagersTeam() != null) {
@@ -699,7 +736,7 @@ public class LobotomizeStorage {
                         v.setSilent(false);
                     }
                     if (this.persistLobotomizedState) {
-                        v.getPersistentDataContainer().remove(this.lobotomizedKey);
+                        clearLobotomizedMarker(v);
                     }
                 } else {
                     setInactive(v);
@@ -708,8 +745,7 @@ public class LobotomizeStorage {
                         v.setSilent(true);
                     }
                     if (this.persistLobotomizedState) {
-                        v.getPersistentDataContainer().set(
-                                this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                        setLobotomizedMarker(v);
                     }
                 }
                 this.logger.info("[Watchdog] Reconciled villager " + v.getUniqueId()

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -334,7 +334,8 @@ public class LobotomizeStorage {
     }
 
     /**
-     * Flushes all tracked villagers from storage, stops their processing tasks, and attempts to un-lobotomize them during shutdown.
+     * Flushes all tracked villagers from storage and stops their processing tasks during shutdown.
+     * Villager state is only restored when {@code uninstall} is enabled in the configuration.
      */
     public final void flush() {
         flush(false);
@@ -358,13 +359,13 @@ public class LobotomizeStorage {
     }
 
     /**
-     * Stops tracking all villagers, cancels their scheduled tasks, and restores their activity state.
+     * Stops tracking all villagers, cancels their scheduled tasks, and optionally restores their
+     * activity state.
      * 
      * @param reloading {@code true} when the plugin remains enabled (such as during a config reload).
      *                  Wake operations are dispatched via each villager's {@code EntityScheduler}, 
      *                  ensuring safe cross-region (Folia) execution. {@code false} during plugin shutdown,
-     *                  where the scheduler may not run; in this case, mutations are attempted directly
-     *                  and the persistent lobotomized marker is relied upon for re-evaluation on chunk load.
+     *                  where villager state is preserved unless {@code uninstall} is enabled.
      */
     public final void flush(boolean reloading) {
         // Prevent new tasks from being scheduled past this point
@@ -373,7 +374,11 @@ public class LobotomizeStorage {
         this.safeCancel(this.chunkProcessingTask);
         this.safeCancel(this.watchdogTask);
 
-        // Wake all villagers before shutdown so they aren't left lobotomized forever if the plugin is removed
+        // Reloads must restore state before the replacement storage rescans villagers. During a normal
+        // shutdown, preserve the state and PDC marker so villagers can be restored immediately on startup.
+        // Administrators explicitly opt into cleanup before permanently removing the plugin.
+        boolean cleanupVillagerState = reloading || this.plugin.getConfig().getBoolean("uninstall", false);
+
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
         // Cancel and clear per-villager tasks under the same lock that scheduleVillagerTask holds, so a
         // concurrent schedule can't install an orphan task after we clear (it re-checks shuttingDown there).
@@ -385,13 +390,24 @@ public class LobotomizeStorage {
             this.villagerTasks.clear();
             this.villagerTaskIntervals.clear();
 
-            toFlush = new ArrayList<>(this.inactiveVillagers.size() + this.activeVillagers.size());
-            toFlush.addAll(this.inactiveVillagers);
-            for (Villager v : this.activeVillagers) {
-                if (!this.inactiveVillagers.contains(v)) toFlush.add(v);
+            if (cleanupVillagerState) {
+                toFlush = new ArrayList<>(this.inactiveVillagers.size() + this.activeVillagers.size());
+                toFlush.addAll(this.inactiveVillagers);
+                for (Villager v : this.activeVillagers) {
+                    if (!this.inactiveVillagers.contains(v)) toFlush.add(v);
+                }
+            } else {
+                toFlush = Collections.emptyList();
             }
             this.inactiveVillagers.clear();
             this.activeVillagers.clear();
+        }
+
+        if (!cleanupVillagerState) {
+            if (this.plugin.isDebugging()) {
+                this.logger.info("Preserved lobotomized Villager state and markers for the next startup.");
+            }
+            return;
         }
 
         // On a true shutdown the scheduler may not run, so cross-region (Folia) villagers can't be

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -203,6 +203,14 @@ public class VillagerLobotomizer extends JavaPlugin {
     @Override
     public void onDisable() {
         getLogger().info("Man guess I'll put my tools away now :(");
+        // Administrators may set uninstall directly in config.yml immediately before stopping.
+        // Refresh the file-backed configuration so shutdown does not rely on a stale cached value.
+        try {
+            this.reloadConfig();
+        } catch (Exception e) {
+            this.getLogger().log(java.util.logging.Level.WARNING,
+                    "Failed to reload config during shutdown; using the last loaded values.", e);
+        }
         if (this.storage != null) {
             this.storage.flush();
         }

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -15,6 +15,7 @@ import org.bstats.charts.MultiLineChart;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
 import org.bukkit.plugin.Plugin;
@@ -24,6 +25,8 @@ import org.bukkit.World;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -34,6 +37,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class VillagerLobotomizer extends JavaPlugin {
+    private static final String STATE_FILE_NAME = "state.yml";
+    private static final String LOBOTOMY_GENERATION_PATH = "lobotomy-generation";
+    private static final String ACCEPT_LEGACY_MARKERS_PATH = "accept-legacy-markers";
     private boolean debugging = false;
     private boolean chunkDebugging = false;
     private LobotomizeStorage storage;
@@ -48,6 +54,8 @@ public class VillagerLobotomizer extends JavaPlugin {
     private final String inactiveVillagersTeamName = "lobotomy_inactive_villagers";
     private boolean disableChunkVillagerUpdate;
     private boolean sentryEnabled = false;
+    private volatile String lobotomyGeneration;
+    private volatile boolean acceptLegacyLobotomyMarkers;
 
     /**
      * Initializes the plugin, loading configuration, storage, listeners, commands, and debug features.
@@ -56,6 +64,7 @@ public class VillagerLobotomizer extends JavaPlugin {
     public void onEnable() {
         ConfigMigrator migrator = new ConfigMigrator(this);
         migrator.migrateConfig();
+        this.loadLobotomyState();
         boolean disableUpdateCheck = this.getConfig().getBoolean("disable-update-checker", false);
         if (!disableUpdateCheck) {
             this.checkForUpdates();
@@ -214,6 +223,9 @@ public class VillagerLobotomizer extends JavaPlugin {
         if (this.storage != null) {
             this.storage.flush();
         }
+        if (this.getConfig().getBoolean("uninstall", false)) {
+            this.invalidateLobotomyMarkers();
+        }
         // No need to cancel tasks manually - Paper handles this automatically on disable
         // Clean up debug teams (non-Folia only)
         if (!this.isFolia) {
@@ -238,6 +250,57 @@ public class VillagerLobotomizer extends JavaPlugin {
                 this.getLogger().log(java.util.logging.Level.WARNING, "Error during Sentry shutdown: " + e.getMessage(), e);
             }
         }
+    }
+
+    /**
+     * Loads the generation used to distinguish current PDC markers from markers invalidated by an
+     * uninstall. Legacy byte markers are accepted until the first uninstall after this upgrade.
+     */
+    private void loadLobotomyState() {
+        File stateFile = new File(this.getDataFolder(), STATE_FILE_NAME);
+        YamlConfiguration state = YamlConfiguration.loadConfiguration(stateFile);
+        String storedGeneration = state.getString(LOBOTOMY_GENERATION_PATH);
+
+        if (storedGeneration == null || storedGeneration.isBlank()) {
+            this.lobotomyGeneration = UUID.randomUUID().toString();
+            this.acceptLegacyLobotomyMarkers = true;
+            this.saveLobotomyState();
+            return;
+        }
+
+        this.lobotomyGeneration = storedGeneration;
+        this.acceptLegacyLobotomyMarkers = state.getBoolean(ACCEPT_LEGACY_MARKERS_PATH, true);
+    }
+
+    /**
+     * Rotates the marker generation so entity data in unloaded chunks is inert if the plugin is
+     * installed again later.
+     */
+    private void invalidateLobotomyMarkers() {
+        this.lobotomyGeneration = UUID.randomUUID().toString();
+        this.acceptLegacyLobotomyMarkers = false;
+        this.saveLobotomyState();
+    }
+
+    private void saveLobotomyState() {
+        YamlConfiguration state = new YamlConfiguration();
+        state.set(LOBOTOMY_GENERATION_PATH, this.lobotomyGeneration);
+        state.set(ACCEPT_LEGACY_MARKERS_PATH, this.acceptLegacyLobotomyMarkers);
+
+        try {
+            state.save(new File(this.getDataFolder(), STATE_FILE_NAME));
+        } catch (IOException e) {
+            this.getLogger().log(java.util.logging.Level.SEVERE,
+                    "Failed to save persistent lobotomy marker state.", e);
+        }
+    }
+
+    String getLobotomyGeneration() {
+        return this.lobotomyGeneration;
+    }
+
+    boolean acceptsLegacyLobotomyMarkers() {
+        return this.acceptLegacyLobotomyMarkers;
     }
 
     /**

--- a/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
@@ -53,9 +53,13 @@ public class EntityListener implements Listener {
 
     @EventHandler
     public final void onUnload(ChunkUnloadEvent event) {
-        if (this.plugin.isChunkDebugging()) {
-            for (Entity entity : event.getChunk().getEntities()) {
-                if (entity instanceof Villager) {
+        for (Entity entity : event.getChunk().getEntities()) {
+            if (entity instanceof Villager villager) {
+                // Entity-scheduler work queued from EntityRemoveFromWorldEvent may be retired before
+                // it executes. Restore AI now so the chunk serializes an aware villager while the PDC
+                // marker remains available to re-lobotomize it immediately on the next load.
+                this.plugin.getStorage().prepareVillagerForUnload(villager);
+                if (this.plugin.isChunkDebugging()) {
                     this.plugin.getLogger().log(Level.INFO, "[Debug] Caught {0} for villager {1} ({2}); The villager should have been removed from the storage", new Object[]{event.getEventName(), entity, entity.getUniqueId()});
                 }
             }

--- a/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/utils/ConfigMigrator.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 public class ConfigMigrator {
     private final JavaPlugin plugin;
     private final Logger logger;
-    private static final int CURRENT_CONFIG_VERSION = 6; // Increment whenever you update the config.yml
+    private static final int CURRENT_CONFIG_VERSION = 7; // Increment whenever you update the config.yml
 
     public ConfigMigrator(JavaPlugin plugin) {
         this.plugin = plugin;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 #Configuration version - DO NOT MODIFY MANUALLY
-config-version: 6
+config-version: 7
 
 #List of names that will always keep villagers active (case-insensitive)
 always-active-names:
@@ -71,6 +71,10 @@ unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized 
 #Persist lobotomized state across chunk unloads. When enabled, villagers that are lobotomized will remain lobotomized when their chunk is unloaded and reloaded.
 #This prevents lag spikes from villagers needing to be re-evaluated and re-lobotomized after chunk loads.
 persist-lobotomized-state: true
+
+#Set this to true before permanently uninstalling the plugin. On disable, all tracked villagers will be woken and their persistent lobotomy markers removed.
+#Keep this false during normal operation so lobotomized state survives server restarts.
+uninstall: false
 
 # ===== SENTRY ERROR TRACKING =====
 # Sentry is an error monitoring service that helps developers identify and fix bugs proactively.

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
@@ -1,0 +1,65 @@
+package dev.mja00.villagerLobotomizer;
+
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LobotomizeStorageTest extends MockBukkitTestBase {
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+    private NamespacedKey lobotomizedKey;
+
+    @BeforeEach
+    void loadPlugin() {
+        plugin = MockBukkit.load(VillagerLobotomizer.class);
+        world = server.addSimpleWorld("test");
+        lobotomizedKey = new NamespacedKey(plugin, "isLobotomized");
+    }
+
+    @Test
+    void shutdownPreservesLobotomizedStateByDefault() {
+        Villager villager = trackedLobotomizedVillager();
+
+        assertFalse(plugin.getConfig().getBoolean("uninstall"),
+                "uninstall cleanup should be disabled by default");
+
+        server.getPluginManager().disablePlugin(plugin);
+
+        assertFalse(villager.isAware(), "normal shutdown should preserve disabled villager AI");
+        assertTrue(hasLobotomizedMarker(villager),
+                "normal shutdown should preserve the persistent lobotomy marker");
+    }
+
+    @Test
+    void uninstallCleanupWakesVillagerAndRemovesMarker() {
+        Villager villager = trackedLobotomizedVillager();
+        plugin.getConfig().set("uninstall", true);
+
+        server.getPluginManager().disablePlugin(plugin);
+
+        assertTrue(villager.isAware(), "uninstall cleanup should restore villager AI");
+        assertFalse(hasLobotomizedMarker(villager),
+                "uninstall cleanup should remove the persistent lobotomy marker");
+    }
+
+    private Villager trackedLobotomizedVillager() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        plugin.getStorage().addVillager(villager);
+        villager.setAware(false);
+        villager.getPersistentDataContainer().set(lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+        return villager;
+    }
+
+    private boolean hasLobotomizedMarker(Villager villager) {
+        return villager.getPersistentDataContainer().has(lobotomizedKey, PersistentDataType.BYTE);
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
@@ -2,12 +2,16 @@ package dev.mja00.villagerLobotomizer;
 
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Villager;
 import org.bukkit.persistence.PersistentDataType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import java.io.File;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +47,7 @@ class LobotomizeStorageTest extends MockBukkitTestBase {
     void uninstallCleanupWakesVillagerAndRemovesMarker() {
         Villager villager = trackedLobotomizedVillager();
         plugin.getConfig().set("uninstall", true);
+        plugin.saveConfig();
 
         server.getPluginManager().disablePlugin(plugin);
 
@@ -51,15 +56,95 @@ class LobotomizeStorageTest extends MockBukkitTestBase {
                 "uninstall cleanup should remove the persistent lobotomy marker");
     }
 
+    @Test
+    void shutdownReadsUninstallSettingDirectlyFromConfigFile() throws IOException {
+        Villager villager = trackedLobotomizedVillager();
+        writeConfigValue("uninstall", true);
+
+        assertFalse(plugin.getConfig().getBoolean("uninstall"),
+                "precondition: the in-memory config should still contain the stale value");
+
+        server.getPluginManager().disablePlugin(plugin);
+
+        assertTrue(villager.isAware(), "file-backed uninstall cleanup should restore villager AI");
+        assertFalse(hasLobotomizedMarker(villager),
+                "file-backed uninstall cleanup should remove the persistent marker");
+    }
+
+    @Test
+    void shutdownWakesMarkerlessVillagerWhenPersistenceIsDisabled() throws IOException {
+        writeConfigValue("persist-lobotomized-state", false);
+        plugin.reloadPluginState();
+
+        Villager villager = trackedMarkerlessVillager();
+        villager.setAware(false);
+
+        server.getPluginManager().disablePlugin(plugin);
+
+        assertTrue(villager.isAware(),
+                "shutdown must wake villagers when no marker can restore them on startup");
+        assertFalse(hasLobotomizedMarker(villager));
+    }
+
+    @Test
+    void addingMarkerlessVillagerRepairsStaleNoAiState() {
+        Villager villager = trackedMarkerlessVillager();
+        plugin.getStorage().removeVillager(villager);
+        villager.setAware(false);
+
+        plugin.getStorage().addVillager(villager);
+
+        assertTrue(villager.isAware(), "active villagers must not retain a stale NoAI state");
+        assertTrue(plugin.getStorage().getActive().contains(villager));
+    }
+
+    @Test
+    void chunkUnloadPreparationWakesVillagerButRetainsMarker() {
+        Villager villager = trackedLobotomizedVillager();
+
+        plugin.getStorage().prepareVillagerForUnload(villager);
+
+        assertTrue(villager.isAware(), "villager AI should be restored before chunk serialization");
+        assertTrue(hasLobotomizedMarker(villager),
+                "the marker should remain so a later chunk load can immediately restore NoAI");
+        assertTrue(plugin.getStorage().getLobotomized().contains(villager),
+                "unload preparation should not race entity-removal tracking");
+    }
+
+    @Test
+    void removingLobotomizedVillagerRestoresAiImmediately() {
+        Villager villager = trackedLobotomizedVillager();
+
+        plugin.getStorage().removeVillager(villager);
+
+        assertTrue(villager.isAware(), "entity removal should not depend on a next-tick callback");
+        assertTrue(hasLobotomizedMarker(villager),
+                "entity removal should retain the restart marker");
+        assertFalse(plugin.getStorage().getLobotomized().contains(villager));
+    }
+
     private Villager trackedLobotomizedVillager() {
         Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
-        plugin.getStorage().addVillager(villager);
-        villager.setAware(false);
+        plugin.getStorage().removeVillager(villager);
         villager.getPersistentDataContainer().set(lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        return villager;
+    }
+
+    private Villager trackedMarkerlessVillager() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        plugin.getStorage().addVillager(villager);
         return villager;
     }
 
     private boolean hasLobotomizedMarker(Villager villager) {
         return villager.getPersistentDataContainer().has(lobotomizedKey, PersistentDataType.BYTE);
+    }
+
+    private void writeConfigValue(String key, Object value) throws IOException {
+        File configFile = new File(plugin.getDataFolder(), "config.yml");
+        YamlConfiguration diskConfig = YamlConfiguration.loadConfiguration(configFile);
+        diskConfig.set(key, value);
+        diskConfig.save(configFile);
     }
 }

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageTest.java
@@ -13,7 +13,9 @@ import org.mockbukkit.mockbukkit.world.WorldMock;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LobotomizeStorageTest extends MockBukkitTestBase {
@@ -123,10 +125,49 @@ class LobotomizeStorageTest extends MockBukkitTestBase {
         assertFalse(plugin.getStorage().getLobotomized().contains(villager));
     }
 
+    @Test
+    void uninstallInvalidatesMarkerFromPreviouslyUnloadedVillager() {
+        Villager villager = trackedLobotomizedVillager();
+        String markerGeneration = villager.getPersistentDataContainer().get(
+                lobotomizedKey, PersistentDataType.STRING);
+        plugin.getStorage().prepareVillagerForUnload(villager);
+        plugin.getStorage().removeVillager(villager);
+        plugin.getConfig().set("uninstall", true);
+        plugin.saveConfig();
+
+        server.getPluginManager().disablePlugin(plugin);
+
+        assertEquals(markerGeneration, villager.getPersistentDataContainer().get(
+                lobotomizedKey, PersistentDataType.STRING),
+                "precondition: an unloaded entity marker cannot be removed during shutdown");
+        assertNotEquals(markerGeneration, plugin.getLobotomyGeneration(),
+                "uninstall should rotate the generation so the unloaded marker becomes stale");
+        YamlConfiguration state = YamlConfiguration.loadConfiguration(
+                new File(plugin.getDataFolder(), "state.yml"));
+        assertEquals(plugin.getLobotomyGeneration(), state.getString("lobotomy-generation"),
+                "the rotated generation must survive a later reinstall");
+    }
+
+    @Test
+    void staleGenerationMarkerIsIgnoredOnLaterLoad() {
+        Villager villager = trackedMarkerlessVillager();
+        plugin.getStorage().removeVillager(villager);
+        villager.getPersistentDataContainer().set(
+                lobotomizedKey, PersistentDataType.STRING, "invalidated-generation");
+        villager.setAware(false);
+
+        plugin.getStorage().addVillager(villager);
+
+        assertTrue(villager.isAware(), "stale uninstall markers must not restore NoAI");
+        assertFalse(hasLobotomizedMarker(villager), "stale uninstall markers should be removed on load");
+        assertTrue(plugin.getStorage().getActive().contains(villager));
+    }
+
     private Villager trackedLobotomizedVillager() {
         Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
         plugin.getStorage().removeVillager(villager);
-        villager.getPersistentDataContainer().set(lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+        villager.getPersistentDataContainer().set(
+                lobotomizedKey, PersistentDataType.STRING, plugin.getLobotomyGeneration());
         plugin.getStorage().addVillager(villager);
         return villager;
     }
@@ -138,7 +179,8 @@ class LobotomizeStorageTest extends MockBukkitTestBase {
     }
 
     private boolean hasLobotomizedMarker(Villager villager) {
-        return villager.getPersistentDataContainer().has(lobotomizedKey, PersistentDataType.BYTE);
+        return villager.getPersistentDataContainer().has(lobotomizedKey, PersistentDataType.STRING)
+                || villager.getPersistentDataContainer().has(lobotomizedKey, PersistentDataType.BYTE);
     }
 
     private void writeConfigValue(String key, Object value) throws IOException {

--- a/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
@@ -5,7 +5,10 @@ import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import dev.mja00.villagerLobotomizer.MockBukkitTestBase;
 import dev.mja00.villagerLobotomizer.VillagerLobotomizer;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.world.ChunkUnloadEvent;
+import org.bukkit.persistence.PersistentDataType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -68,5 +71,21 @@ class EntityListenerTest extends MockBukkitTestBase {
         new EntityListener(plugin);
 
         assertTrue(isTracked(villager), "existing villagers should be picked up by the constructor scan");
+    }
+
+    @Test
+    void chunkUnloadRestoresAiBeforeEntityRemoval() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        NamespacedKey marker = new NamespacedKey(plugin, "isLobotomized");
+        plugin.getStorage().removeVillager(villager);
+        villager.getPersistentDataContainer().set(marker, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        assertFalse(villager.isAware(), "precondition: marked villager is lobotomized");
+
+        server.getPluginManager().callEvent(new ChunkUnloadEvent(villager.getChunk()));
+
+        assertTrue(villager.isAware(), "chunk unload should serialize the villager with AI enabled");
+        assertTrue(villager.getPersistentDataContainer().has(marker, PersistentDataType.BYTE),
+                "chunk unload should retain the marker for immediate restoration on load");
     }
 }

--- a/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
@@ -85,7 +85,7 @@ class EntityListenerTest extends MockBukkitTestBase {
         server.getPluginManager().callEvent(new ChunkUnloadEvent(villager.getChunk()));
 
         assertTrue(villager.isAware(), "chunk unload should serialize the villager with AI enabled");
-        assertTrue(villager.getPersistentDataContainer().has(marker, PersistentDataType.BYTE),
-                "chunk unload should retain the marker for immediate restoration on load");
+        assertTrue(villager.getPersistentDataContainer().has(marker, PersistentDataType.STRING),
+                "chunk unload should retain and migrate the marker for immediate restoration on load");
     }
 }

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1,5 +1,5 @@
 #Configuration version - DO NOT MODIFY MANUALLY
-config-version: 6
+config-version: 7
 
 #List of names that will always keep villagers active (case-insensitive)
 always-active-names:
@@ -67,6 +67,9 @@ unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized 
 
 #Persist lobotomized state across chunk unloads.
 persist-lobotomized-state: true
+
+#Keep shutdown state by default.
+uninstall: false
 
 #Sentry disabled for tests to avoid network init during MockBukkit.load().
 enable-sentry: false


### PR DESCRIPTION
Makes PDC persist reboots by default, with a new `uninstall` flag triggering the full flush. 