### PR TITLE
feat: persist lobotomized state across restarts and add /lobotomy uninstall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,14 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 ## Commands
 - Build: `./gradlew build`
 - Test Server: `./gradlew runServer`
-- In-game: `/lobotomy info|debug|wake|reload`
+- In-game: `/lobotomy info|debug|wake|reload|uninstall`
 
 ## Architecture
+
+### Shutdown vs uninstall
+`flush(FlushMode.SHUTDOWN)` **preserves** no-AI state and markers when persistence is on, so a restart does not un-lobotomize every trading hall. `FlushMode.RELOAD` still wakes and clears, because the replacement storage rescans immediately. `quiesceForUninstall()` stops everything without touching a villager; `UninstallSweep` owns all entity work from there.
+
+Note `processVillager`'s active branch wakes on every check, not just on transition: a villager tracked active but left asleep would otherwise stay frozen and, with trade prevention on, untradeable.
 
 ### Threading
 - Per-entity tasks via `EntityScheduler` (thread-safe villager operations)
@@ -30,18 +35,22 @@ Note: The project is misspelled on purpose. You'll need to use VillagerLobotomiz
 - `BlockClassifier` - Material sets (`impassableRegular`, `impassableTall`, `impassableAll`, `cropBlocks`, `doorBlocks`, `professionBlocks`), built once via `fromServerRegistry()`
 - `BlockSnapshot` (type/passable/solid), `BlockGrid` (coord→snapshot, `null`=unloaded), `VillagerState` (villager properties)
 
-**EntityListener.java** - Events: `EntityAddToWorldEvent`, `EntityRemoveFromWorldEvent`, `BlockBreakEvent/PlaceEvent` (chunk updates), `InventoryOpenEvent` (optional trade prevention via merchant-inventory check)
+**storage/** - `LobotomizedMarkerStore` (SQLite `state.db`) records which villagers carry the PDC marker, so uninstall can reach ones in unloaded chunks. Invariant: **a row exists exactly when the marker is written**. Writes go through a single intent map mutated via `compute()` and drained on an async task every 5s; suppression in both directions keeps steady-state writes near zero. `org.sqlite` is shaded **unrelocated** (the bundled native has `org/sqlite/core/NativeDB` compiled into its JNI bindings) and opened via `SQLiteDataSource`, never `DriverManager`.
 
-**LobotomizeCommand.java** - Brigadier commands registered via `LifecycleEvents.COMMANDS`, permission `lobotomy.command` (op), raycasting for targeting. Wake command clears `isLobotomized` PDC marker.
+**UninstallSweep.java** - `/lobotomy uninstall confirm`: quiesces storage, restores every loaded villager via its `EntityScheduler`, then walks remaining rows chunk-by-chunk (`getChunkAtAsync` with `generate=false`, 8 in flight, `isOwnedByCurrentRegion` guard then a `RegionScheduler` hop) plus a 3x3 second pass for stale coords. Keeps `state.db` and stays enabled if anything is skipped or unresolved; otherwise deletes it and self-disables.
+
+**EntityListener.java** - Events: `EntityAddToWorldEvent`, `EntityRemoveFromWorldEvent`, `EntityRemoveEvent` (drops the tracking row for non-`UNLOAD` causes; `isDead()`/`isValid()` cannot tell death from unload), `BlockBreakEvent/PlaceEvent` (chunk updates), `InventoryOpenEvent` (optional trade prevention via merchant-inventory check)
+
+**LobotomizeCommand.java** - Brigadier commands registered via `LifecycleEvents.COMMANDS`, permission `lobotomy.command` (op), raycasting for targeting. Wake command clears `isLobotomized` PDC marker. `uninstall` requires an explicit `confirm` literal.
 
 **VillagerUtils.java** - Maps: `PROFESSION_TO_STATION`, `PROFESSION_TO_SOUND`. Methods: `isJobSiteNearby()` (3x3x3 box), `shouldRestock()` (PDC+day-time logic)
 
 ### Config (read in constructors)
-`check-interval`, `inactive-check-interval`, `restock-interval`, `restock-random-range`, `restock-sound`, `level-up-sound`, `debug`, `chunk-debug`, `create-debug-teams` (Folia-incompatible), `check-roof`, `ignore-non-solid-blocks`, `disable-chunk-villager-updates`, `persist-lobotomized-state`
+`check-interval`, `inactive-check-interval`, `restock-interval`, `restock-random-range`, `restock-sound`, `level-up-sound`, `debug`, `chunk-debug`, `create-debug-teams` (Folia-incompatible), `check-roof`, `ignore-non-solid-blocks`, `disable-chunk-villager-updates`, `persist-lobotomized-state` (also gates opening `state.db`; forced off for the session if it cannot be opened)
 
 ### PDC Keys
 - `lastRestock` (LONG): Last trade refresh timestamp
-- `isLobotomized` (BYTE): Persistence marker (when `persist-lobotomized-state: true`)
+- `isLobotomized` (BYTE): Persistence marker (when `persist-lobotomized-state: true`). Survives restarts; mirrored by a row in `state.db`. Only ever written/cleared via `setLobotomizedMarker`/`clearLobotomizedMarker`, which keep the row in sync
 - `lastRestockCheckDayTime` (LONG): Full game time (absolute ticks) at last restock check; used for day-rollover detection
 
 ## Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,19 @@ Note `processVillager`'s active branch wakes on every check, not just on transit
 - Sounds: `RegistryAccess.registryAccess().getRegistry(RegistryKey.SOUND_EVENT)` with NamespacedKeys
 - Legacy sounds: Convert via `StringUtils.convertLegacySoundNameFormat()`
 
+### Testing limits (MockBukkit 4.110)
+These throw `UnimplementedOperationException`, which JUnit reports as a **skipped** test rather than a
+failure, so a test that hits one looks green:
+- `BlockMock#isPassable` - so anything reaching `VillagerActivityPolicy` via live blocks is untestable.
+  Test the policy purely (see `policy/VillagerActivityPolicyTest`) and drive storage through
+  `addVillager` with a pre-set marker to skip the geometry.
+- `WorldMock#getChunkAtAsync`, `WorldMock#getPlayersSeeingChunk` - hence `UninstallSweep.ChunkAccessor`.
+- `PaperScheduledTask#cancel` - swallow cancel failures, as `safeCancel` already does.
+
+Also: mock chunks are unloaded by default (`world.loadChunk(x, z)` first, or `processVillager` bails),
+and `ChunkMock#isEntitiesLoaded` just returns `isLoaded()`. Always check the run for `skipped=0`, not
+just `failures=0`.
+
 ### Patterns
 - Early returns, guard clauses
 - Gate debug logs: `plugin.isDebugging()`, `plugin.isChunkDebugging()`

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ A Minecraft Paper plugin that improves server performance by turning off village
 - `/lobotomy debug toggle` - Toggles debug mode
 - `/lobotomy wake` - Manually restores AI to the villager you're looking at
 - `/lobotomy reload` - Reloads the configuration and applies changes to all villagers
+- `/lobotomy uninstall` - Explains what removing the plugin will do, without doing it
+- `/lobotomy uninstall confirm` - Restores AI to every villager the plugin has lobotomized, clears its data from them, then disables the plugin
 
 ## Configuration
 
 ```yaml
 #Configuration version - DO NOT MODIFY MANUALLY
-config-version: 4
+config-version: 6
 
 #List of names that will always keep villagers active (case-insensitive)
 always-active-names:
@@ -91,6 +93,7 @@ check-roof: true
 create-debug-teams: false
 
 #Disable the update checker. You can disable this if you don't want to be notified about updates.
+#Note: this is only read when the plugin loads; changing it requires a server restart (a /lobotomy reload will not re-run the update check).
 disable-update-checker: false
 
 #Disable chunk forced Villager updating. This'll disable changes to blocks in a chunk from triggering Villagers in the chunk to be updated.
@@ -99,11 +102,41 @@ disable-chunk-villager-updates: false
 #Prevent trading with unlobotomized villagers. When enabled, players can only trade with villagers that have been lobotomized.
 prevent-trading-with-unlobotomized-villagers: false
 
-#Persist lobotomized state across chunk unloads. When enabled, villagers that are lobotomized will remain lobotomized when their chunk is unloaded and reloaded.
-#This prevents lag spikes from villagers needing to be re-evaluated and re-lobotomized after chunk loads.
+#Message that is sent to players when they try to trade with an unlobotomized villager. Supports MiniMessage.
+unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>"
+
+#Persist lobotomized state across chunk unloads and server restarts. When enabled, lobotomized villagers stay lobotomized, so there is no lag spike while they are re-evaluated after a chunk load or a reboot.
+#Run '/lobotomy uninstall' before removing the plugin. Deleting the jar on its own leaves those villagers without AI, because nothing is left to restore them.
 persist-lobotomized-state: true
 
-#Enable Sentry error tracking to help developers identify and fix bugs. See "Privacy & Telemetry" section below for details.
+# ===== SENTRY ERROR TRACKING =====
+# Sentry is an error monitoring service that helps developers identify and fix bugs proactively.
+# When enabled, the plugin will automatically report crashes and exceptions to the developers.
+#
+# WHAT DATA IS COLLECTED:
+#   - Exception stack traces and error messages
+#   - Server type and version (Paper, Purpur, Folia, etc.)
+#   - Minecraft version and Bukkit API version
+#   - Java version
+#   - Plugin version
+#   - Thread information and task scheduling context
+#
+# WHAT DATA IS NOT COLLECTED:
+#   - Player names, UUIDs, or any player-identifiable information
+#   - Chat messages or commands
+#   - World data, coordinates, or block information
+#   - Server IP address or hostname
+#   - Server configuration (beyond this plugin's settings)
+#
+# WHY KEEP THIS ENABLED:
+#   - Helps developers discover and fix bugs you might not even report
+#   - Provides context to fix issues specific to your server setup (Folia vs Paper, Java version, etc.)
+#   - Errors are sent automatically - no need to manually report bugs
+#   - All data is anonymized and used solely for debugging purposes
+#
+# PRIVACY: No personally identifiable information (PII) is collected. Only technical error data is sent.
+#
+# Set to false if you prefer not to share error reports with developers.
 enable-sentry: true
 ```
 
@@ -169,6 +202,15 @@ All error data is anonymized and used solely for debugging purposes.
 2. Place the .jar file in your server's plugins folder
 3. Restart your server or use a plugin manager to load the plugin
 4. Configure the plugin settings in `plugins/VillagerLobotimizer/config.yml` if needed
+
+### Uninstalling
+
+Run `/lobotomy uninstall confirm` before deleting the jar.
+
+Lobotomized villagers have their AI disabled on disk, so they stay that way whether or not the plugin
+is installed. The command restores every villager the plugin has touched, loading chunks as needed to
+reach the ones that are not in memory, removes its data from them, and then disables itself. Deleting
+the jar without running it leaves those villagers without AI and nothing left to fix them.
 
 ## Development
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("net.kyori:adventure-text-serializer-plain:4.22.0")
     implementation("org.bstats:bstats-bukkit:3.1.0")
     implementation("io.sentry:sentry:8.28.0")
+    implementation("org.xerial:sqlite-jdbc:3.53.2.1")
     implementation("org.yaml:snakeyaml:2.2")
     // Plain paper-api for tests: MockBukkit ships no paper-api, and paperweight's NMS server is
     // kept off the test classpath (see paperweight block) to avoid a duplicate server impl.
@@ -103,7 +104,11 @@ tasks {
     }
 
     shadowJar {
-        minimize()
+        // sqlite-jdbc resolves classes and its bundled natives at runtime, so minimize would strip
+        // parts of the driver that static analysis cannot see.
+        minimize {
+            exclude(dependency("org.xerial:sqlite-jdbc"))
+        }
 
         archiveClassifier = null
         archiveVersion = project.version.toString()
@@ -112,10 +117,30 @@ tasks {
             include(dependency("org.bstats:bstats-bukkit"))
             include(dependency("org.bstats:bstats-base"))
             include(dependency("io.sentry:sentry"))
+            include(dependency("org.xerial:sqlite-jdbc"))
         }
 
         relocate("org.bstats", "dev.mja00.villagerLobotomizer.bstats")
         relocate("io.sentry", "dev.mja00.villagerLobotomizer.sentry")
+        // org.sqlite is deliberately NOT relocated: the bundled native library has the JNI class
+        // name org/sqlite/core/NativeDB compiled into it, so a renamed package fails to link. The
+        // usual hazard of shading it unrelocated is the JVM-global JDBC registry, which we avoid by
+        // opening connections through SQLiteDataSource and shipping no driver service file.
+        exclude("META-INF/services/java.sql.Driver")
+        exclude("META-INF/native-image/org.xerial/**")
+
+        // sqlite-jdbc bundles a ~1MB native library per platform. Keep only the ones a Paper server
+        // realistically runs on; the rest would triple the download for nothing.
+        exclude("org/sqlite/native/FreeBSD/**")
+        exclude("org/sqlite/native/Linux/arm/**")
+        exclude("org/sqlite/native/Linux/armv6/**")
+        exclude("org/sqlite/native/Linux/armv7/**")
+        exclude("org/sqlite/native/Linux/ppc64/**")
+        exclude("org/sqlite/native/Linux/riscv64/**")
+        exclude("org/sqlite/native/Linux/x86/**")
+        exclude("org/sqlite/native/Linux-Musl/x86/**")
+        exclude("org/sqlite/native/Windows/armv7/**")
+        exclude("org/sqlite/native/Windows/x86/**")
 
         // Optionally include sources for better Sentry source context
         // Set -PincludeSources=true to enable (increases JAR size)

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeCommand.java
@@ -12,6 +12,8 @@ import org.bukkit.entity.Villager;
 import org.bukkit.util.RayTraceResult;
 import org.jetbrains.annotations.Nullable;
 
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
+
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
@@ -50,6 +52,11 @@ public class LobotomizeCommand {
                 .then(Commands.literal("reload")
                         .requires((command) -> command.getSender().hasPermission("lobotomy.command.reload"))
                         .executes((command) -> reloadCommand(command.getSource())))
+                .then(Commands.literal("uninstall")
+                        .requires((command) -> command.getSender().hasPermission("lobotomy.command.uninstall"))
+                        .executes((command) -> uninstallCommand(command.getSource()))
+                        .then(Commands.literal("confirm")
+                                .executes((command) -> uninstallConfirmCommand(command.getSource()))))
                 .then(Commands.literal("config")
                         .requires((command) -> command.getSender().hasPermission("lobotomy.command.config"))
                         .then(Commands.argument("key", StringArgumentType.string()).suggests(LobotomizeCommand::getConfigKeySuggestions)
@@ -70,7 +77,8 @@ public class LobotomizeCommand {
                 || sender.hasPermission("lobotomy.command.debug")
                 || sender.hasPermission("lobotomy.command.wake")
                 || sender.hasPermission("lobotomy.command.reload")
-                || sender.hasPermission("lobotomy.command.config");
+                || sender.hasPermission("lobotomy.command.config")
+                || sender.hasPermission("lobotomy.command.uninstall");
     }
 
     /**
@@ -212,6 +220,41 @@ public class LobotomizeCommand {
         this.plugin.getStorage().removeVillager(villager);
         this.plugin.getStorage().clearLobotomizedMarker(villager);
         source.getSender().sendMessage(Component.text("This villager will now be unaffected by the plugin until the chunk is reloaded."));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Explains what the sweep does without running it. Requiring an explicit confirm keeps a mistyped
+     * command from force-loading chunks across every world.
+     */
+    private int uninstallCommand(CommandSourceStack source) {
+        CommandSender sender = source.getSender();
+        LobotomizedMarkerStore store = this.plugin.getMarkerStore();
+        int tracked = store == null ? 0 : store.getKnownRowCount();
+
+        sender.sendMessage(Component.text("This restores AI to every villager the plugin has lobotomized, "
+                + "removes its data from them, then disables the plugin.").color(NamedTextColor.YELLOW));
+        sender.sendMessage(Component.text("Villagers still marked: ")
+                .append(Component.text(String.valueOf(tracked)).color(NamedTextColor.GREEN)));
+        sender.sendMessage(Component.text("Chunks will be loaded to reach villagers that are not in memory, "
+                + "which also fires other plugins' chunk load handlers.").color(NamedTextColor.YELLOW));
+        if (this.plugin.getConfig().getBoolean("prevent-trading-with-unlobotomized-villagers")) {
+            sender.sendMessage(Component.text("Trading will be blocked while the sweep runs.")
+                    .color(NamedTextColor.YELLOW));
+        }
+        sender.sendMessage(Component.text("Run '/lobotomy uninstall confirm' to proceed.").color(NamedTextColor.RED));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int uninstallConfirmCommand(CommandSourceStack source) {
+        CommandSender sender = source.getSender();
+        if (!this.plugin.startUninstall(sender)) {
+            sender.sendMessage(Component.text("Could not start the uninstall; one may already be running. "
+                    + "Check the console for details.").color(NamedTextColor.RED));
+            return 0;
+        }
+        sender.sendMessage(Component.text("Uninstall started. Progress is reported here and in the console.")
+                .color(NamedTextColor.GREEN));
         return Command.SINGLE_SUCCESS;
     }
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -265,6 +265,14 @@ public class LobotomizeStorage {
                 this.logger.info("[Debug] Re-lobotomized villager " + villager + " (" + villager.getUniqueId() + ") on chunk load");
             }
         } else {
+            // A villager can load asleep with no valid marker (persistence off, or an unusable state
+            // file); processVillager only wakes on transition, so repair it here instead of leaving it frozen.
+            if (!villager.isAware()) {
+                villager.setAware(true);
+                if (this.silentLobotomizedVillagers) {
+                    villager.setSilent(false);
+                }
+            }
             setActive(villager);
 
             if (this.plugin.isDebugging()) {
@@ -532,12 +540,16 @@ public class LobotomizeStorage {
             // Clear any stale marker whenever the villager should be active, not just on transition,
             // so a marker left by a prior persist-enabled run can't re-lobotomize it after a config flip.
             clearLobotomizedMarker(villager);
-            if (!active) {
+            // Wake on every check rather than only on transition: a villager tracked active but asleep
+            // would otherwise never be woken, leaving it frozen and untradeable.
+            if (!villager.isAware()) {
                 // Already running on entity thread, safe to modify villager
                 villager.setAware(true);
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(false);
                 }
+            }
+            if (!active) {
                 setActive(villager);
                 if (this.plugin.isDebugging()) {
                     this.logger.info("[Debug] Villager " + villager + " (" + villager.getUniqueId() + ") is now active");

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -81,7 +81,7 @@ public class LobotomizeStorage {
     private final boolean lobotomizePassengers;
     private final boolean checkRoof;
     private final boolean silentLobotomizedVillagers;
-    private final boolean persistLobotomizedState;
+    private final boolean persistConfigured;
     private final boolean ignoreStuckInDoors;
     private final VillagerActivityPolicy activityPolicy;
     private Sound restockSound;
@@ -117,10 +117,7 @@ public class LobotomizeStorage {
         this.checkRoof = plugin.getConfig().getBoolean("check-roof");
         this.silentLobotomizedVillagers = plugin.getConfig().getBoolean("silent-lobotomized-villagers");
         this.markerStore = plugin.getMarkerStore();
-        // Without a row per marker the uninstall sweep cannot find these villagers, so when the state
-        // file is unusable we must not write markers at all.
-        this.persistLobotomizedState = plugin.getConfig().getBoolean("persist-lobotomized-state", true)
-                && this.markerStore != null && this.markerStore.isUsable();
+        this.persistConfigured = plugin.getConfig().getBoolean("persist-lobotomized-state", true);
         String soundName = plugin.getConfig().getString("restock-sound", "");
         String levelUpSoundName = plugin.getConfig().getString("level-up-sound", "");
 
@@ -265,7 +262,7 @@ public class LobotomizeStorage {
         }
 
         boolean wasLobotomized = false;
-        if (this.persistLobotomizedState) {
+        if (persistLobotomizedState()) {
             PersistentDataContainer pdc = villager.getPersistentDataContainer();
             wasLobotomized = pdc.has(this.lobotomizedKey, PersistentDataType.BYTE);
         }
@@ -366,6 +363,14 @@ public class LobotomizeStorage {
         if (this.markerStore != null) {
             this.markerStore.markerCleared(villager.getUniqueId());
         }
+    }
+
+    /**
+     * Whether markers may be written right now. Checked live rather than cached at construction: the
+     * store can degrade mid-session, and a marker without a row is invisible to the uninstall sweep.
+     */
+    private boolean persistLobotomizedState() {
+        return this.persistConfigured && this.markerStore != null && this.markerStore.isUsable();
     }
 
     /**
@@ -484,7 +489,7 @@ public class LobotomizeStorage {
         // Leave both the no-AI state and the marker in place across a restart, or every trading hall
         // is un-lobotomized on boot and the lag spike comes back until check-interval elapses.
         // '/lobotomy uninstall' is what undoes it all when the plugin is being removed for good.
-        if (mode == FlushMode.SHUTDOWN && this.persistLobotomizedState) {
+        if (mode == FlushMode.SHUTDOWN && persistLobotomizedState()) {
             if (this.plugin.isDebugging()) {
                 this.logger.info("[Debug] Preserved lobotomized state for " + toFlush.size() + " villager(s)");
             }
@@ -659,7 +664,7 @@ public class LobotomizeStorage {
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(true);
                 }
-                if (this.persistLobotomizedState) {
+                if (persistLobotomizedState()) {
                     setLobotomizedMarker(villager);
                     if (this.plugin.isDebugging()) {
                         this.logger.info("[Debug] Set persistent lobotomized marker for " + villager.getUniqueId());
@@ -678,13 +683,13 @@ public class LobotomizeStorage {
                 if (this.silentLobotomizedVillagers) {
                     villager.setSilent(true);
                 }
-                if (this.persistLobotomizedState) {
+                if (persistLobotomizedState()) {
                     setLobotomizedMarker(villager);
                 }
             }
             // A lobotomized villager can still be pushed across a chunk border, which would send the
             // uninstall sweep to the wrong chunk. The store ignores this when the chunk is unchanged.
-            if (this.persistLobotomizedState && this.markerStore != null) {
+            if (persistLobotomizedState()) {
                 this.markerStore.markerWritten(villager);
             }
             if (this.plugin.isDebugging() && !this.plugin.isFolia() && this.plugin.getInactiveVillagersTeam() != null) {
@@ -750,7 +755,7 @@ public class LobotomizeStorage {
                     if (this.silentLobotomizedVillagers) {
                         v.setSilent(true);
                     }
-                    if (this.persistLobotomizedState) {
+                    if (persistLobotomizedState()) {
                         setLobotomizedMarker(v);
                     }
                 }

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -52,6 +52,14 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 public class LobotomizeStorage {
     private final VillagerLobotomizer plugin;
     private final NamespacedKey key;
+    /** Why tracking is being torn down, which decides whether villager state is preserved. */
+    public enum FlushMode {
+        /** Server stopping. State and markers are preserved when persistence is enabled. */
+        SHUTDOWN,
+        /** Config reload. Always wakes and clears, because a replacement storage rescans immediately. */
+        RELOAD
+    }
+
     /** Shared so UninstallSweep can rebuild the key without depending on a live storage instance. */
     public static final String LOBOTOMIZED_KEY = "isLobotomized";
 
@@ -375,7 +383,15 @@ public class LobotomizeStorage {
      * Flushes all tracked villagers from storage, stops their processing tasks, and attempts to un-lobotomize them during shutdown.
      */
     public final void flush() {
-        flush(false);
+        flush(FlushMode.SHUTDOWN);
+    }
+
+    /**
+     * @deprecated use {@link #flush(FlushMode)}; kept because this is public API other plugins may call
+     */
+    @Deprecated
+    public final void flush(boolean reloading) {
+        flush(reloading ? FlushMode.RELOAD : FlushMode.SHUTDOWN);
     }
 
     /**
@@ -437,7 +453,8 @@ public class LobotomizeStorage {
      *                  where the scheduler may not run; in this case, mutations are attempted directly
      *                  and the persistent lobotomized marker is relied upon for re-evaluation on chunk load.
      */
-    public final void flush(boolean reloading) {
+    public final void flush(@NotNull FlushMode mode) {
+        boolean reloading = mode == FlushMode.RELOAD;
         // Prevent new tasks from being scheduled past this point
         this.shuttingDown = true;
 
@@ -465,12 +482,22 @@ public class LobotomizeStorage {
             this.activeVillagers.clear();
         }
 
+        // Leave both the no-AI state and the marker in place across a restart, or every trading hall
+        // is un-lobotomized on boot and the lag spike comes back until check-interval elapses.
+        // '/lobotomy uninstall' is what undoes it all when the plugin is being removed for good.
+        if (mode == FlushMode.SHUTDOWN && this.persistLobotomizedState) {
+            if (this.plugin.isDebugging()) {
+                this.logger.info("[Debug] Preserved lobotomized state for " + toFlush.size() + " villager(s)");
+            }
+            return;
+        }
+
         // On a true shutdown the scheduler may not run, so cross-region (Folia) villagers can't be
-        // reliably woken; warn once. The persistent marker (when enabled) re-tracks them on next
-        // load so the normal check loop can wake them once their chunk is active again.
+        // reliably woken; say so once. Their marker is already gone, so the next check after a reload
+        // wakes them once their chunk is active again.
         if (!reloading && this.plugin.isFolia() && !toFlush.isEmpty()) {
             this.logger.info("Some Villagers may remain lobotomized after shutdown until their chunk next loads. "
-                    + "Enable persist-lobotomized-state so they are re-evaluated and woken once their chunk reloads.");
+                    + "Run '/lobotomy uninstall' before removing the plugin to restore every villager.");
         }
 
         for (Villager villager : toFlush) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -39,6 +39,7 @@ import dev.mja00.villagerLobotomizer.policy.BlockGrid;
 import dev.mja00.villagerLobotomizer.policy.BlockSnapshot;
 import dev.mja00.villagerLobotomizer.policy.VillagerActivityPolicy;
 import dev.mja00.villagerLobotomizer.policy.VillagerState;
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
 import dev.mja00.villagerLobotomizer.utils.SentryTaskWrapper;
 import dev.mja00.villagerLobotomizer.utils.StringUtils;
 import dev.mja00.villagerLobotomizer.utils.VillagerUtils;
@@ -51,7 +52,11 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 public class LobotomizeStorage {
     private final VillagerLobotomizer plugin;
     private final NamespacedKey key;
+    /** Shared so UninstallSweep can rebuild the key without depending on a live storage instance. */
+    public static final String LOBOTOMIZED_KEY = "isLobotomized";
+
     private final NamespacedKey lobotomizedKey;
+    private final LobotomizedMarkerStore markerStore;
     private final NamespacedKey lastRestockCheckDayTimeKey;
     private final Set<Villager> activeVillagers = Collections.newSetFromMap(new ConcurrentHashMap<>(128));
     private final Set<Villager> inactiveVillagers = Collections.newSetFromMap(new ConcurrentHashMap<>(128));
@@ -103,7 +108,11 @@ public class LobotomizeStorage {
         this.lobotomizePassengers = plugin.getConfig().getBoolean("always-lobotomize-villagers-in-vehicles");
         this.checkRoof = plugin.getConfig().getBoolean("check-roof");
         this.silentLobotomizedVillagers = plugin.getConfig().getBoolean("silent-lobotomized-villagers");
-        this.persistLobotomizedState = plugin.getConfig().getBoolean("persist-lobotomized-state", true);
+        this.markerStore = plugin.getMarkerStore();
+        // Without a row per marker the uninstall sweep cannot find these villagers, so when the state
+        // file is unusable we must not write markers at all.
+        this.persistLobotomizedState = plugin.getConfig().getBoolean("persist-lobotomized-state", true)
+                && this.markerStore != null && this.markerStore.isUsable();
         String soundName = plugin.getConfig().getString("restock-sound", "");
         String levelUpSoundName = plugin.getConfig().getString("level-up-sound", "");
 
@@ -177,7 +186,7 @@ public class LobotomizeStorage {
         }
 
         this.key = new NamespacedKey(plugin, "lastRestock");
-        this.lobotomizedKey = new NamespacedKey(plugin, "isLobotomized");
+        this.lobotomizedKey = new NamespacedKey(plugin, LOBOTOMIZED_KEY);
         this.lastRestockCheckDayTimeKey = new NamespacedKey(plugin, "lastRestockCheckDayTime");
         // Use Paper's GlobalRegionScheduler for chunk processing. It never touches entities directly;
         // per-chunk entity access is dispatched to the owning region via getRegionScheduler() (see
@@ -260,6 +269,11 @@ public class LobotomizeStorage {
                 villager.setSilent(true);
             }
             setInactive(villager);
+            // Re-record the row: it may be missing (upgraded install, deleted state file) and the
+            // chunk may have changed since we last saw it.
+            if (this.markerStore != null) {
+                this.markerStore.markerWritten(villager);
+            }
 
             if (this.plugin.isDebugging()) {
                 this.logger.info("[Debug] Re-lobotomized villager " + villager + " (" + villager.getUniqueId() + ") on chunk load");
@@ -339,6 +353,22 @@ public class LobotomizeStorage {
                 this.logger.info("[Debug] Removed persistent lobotomized marker from " + villager.getUniqueId());
             }
         }
+        // Outside the guard on purpose: a row can outlive its marker when a chunk never saved, and
+        // clearing one we do not hold is free.
+        if (this.markerStore != null) {
+            this.markerStore.markerCleared(villager.getUniqueId());
+        }
+    }
+
+    /**
+     * Writes the persistent lobotomized marker and records where to find the villager again, so
+     * {@code /lobotomy uninstall} can reach it even from an unloaded chunk.
+     */
+    private void setLobotomizedMarker(@NotNull Villager villager) {
+        villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+        if (this.markerStore != null) {
+            this.markerStore.markerWritten(villager);
+        }
     }
 
     /**
@@ -346,6 +376,39 @@ public class LobotomizeStorage {
      */
     public final void flush() {
         flush(false);
+    }
+
+    /**
+     * Stops all plugin activity and hands back everything that was tracked, without touching a single
+     * villager. Unlike {@link #flush()} this neither wakes villagers nor clears markers, because the
+     * uninstall sweep owns that work and must be the only writer from here on.
+     *
+     * @return every villager that was being tracked when activity stopped
+     */
+    public final @NotNull List<Villager> quiesceForUninstall() {
+        this.shuttingDown = true;
+
+        this.safeCancel(this.chunkProcessingTask);
+        this.safeCancel(this.watchdogTask);
+
+        synchronized (this.stateLock) {
+            for (ScheduledTask task : this.villagerTasks.values()) {
+                this.safeCancel(task);
+            }
+            this.villagerTasks.clear();
+            this.villagerTaskIntervals.clear();
+
+            List<Villager> tracked = new ArrayList<>(this.inactiveVillagers.size() + this.activeVillagers.size());
+            tracked.addAll(this.inactiveVillagers);
+            for (Villager villager : this.activeVillagers) {
+                if (!this.inactiveVillagers.contains(villager)) {
+                    tracked.add(villager);
+                }
+            }
+            this.inactiveVillagers.clear();
+            this.activeVillagers.clear();
+            return tracked;
+        }
     }
 
     /**
@@ -571,7 +634,7 @@ public class LobotomizeStorage {
                     villager.setSilent(true);
                 }
                 if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                    setLobotomizedMarker(villager);
                     if (this.plugin.isDebugging()) {
                         this.logger.info("[Debug] Set persistent lobotomized marker for " + villager.getUniqueId());
                     }
@@ -590,8 +653,13 @@ public class LobotomizeStorage {
                     villager.setSilent(true);
                 }
                 if (this.persistLobotomizedState) {
-                    villager.getPersistentDataContainer().set(this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                    setLobotomizedMarker(villager);
                 }
+            }
+            // A lobotomized villager can still be pushed across a chunk border, which would send the
+            // uninstall sweep to the wrong chunk. The store ignores this when the chunk is unchanged.
+            if (this.persistLobotomizedState && this.markerStore != null) {
+                this.markerStore.markerWritten(villager);
             }
             if (this.plugin.isDebugging() && !this.plugin.isFolia() && this.plugin.getInactiveVillagersTeam() != null) {
                 this.plugin.getInactiveVillagersTeam().addEntity(villager);
@@ -633,6 +701,11 @@ public class LobotomizeStorage {
     private void reconcile(@NotNull Villager v) {
         try {
             v.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((t) -> {
+                // Already queued when flush ran: re-asserting a marker now would outlive the
+                // uninstall sweep that just cleared it.
+                if (this.shuttingDown) {
+                    return;
+                }
                 if (!v.isValid() || v.isDead()) {
                     untrack(v);
                     return;
@@ -644,9 +717,7 @@ public class LobotomizeStorage {
                     if (this.silentLobotomizedVillagers) {
                         v.setSilent(false);
                     }
-                    if (this.persistLobotomizedState) {
-                        v.getPersistentDataContainer().remove(this.lobotomizedKey);
-                    }
+                    clearLobotomizedMarker(v);
                 } else {
                     setInactive(v);
                     v.setAware(false);
@@ -654,8 +725,7 @@ public class LobotomizeStorage {
                         v.setSilent(true);
                     }
                     if (this.persistLobotomizedState) {
-                        v.getPersistentDataContainer().set(
-                                this.lobotomizedKey, PersistentDataType.BYTE, (byte) 1);
+                        setLobotomizedMarker(v);
                     }
                 }
                 this.logger.info("[Watchdog] Reconciled villager " + v.getUniqueId()
@@ -866,7 +936,7 @@ public class LobotomizeStorage {
         try {
             Bukkit.getRegionScheduler().run(this.plugin, world, cx, cz, SentryTaskWrapper.wrap((scheduledTask) -> {
                 // Re-check liveness: the region task runs a tick or more after we were scheduled.
-                if (!chunk.isLoaded()) {
+                if (this.shuttingDown || !chunk.isLoaded()) {
                     return;
                 }
                 for (Entity entity : chunk.getEntities()) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/LobotomizeStorage.java
@@ -461,7 +461,6 @@ public class LobotomizeStorage {
         this.safeCancel(this.chunkProcessingTask);
         this.safeCancel(this.watchdogTask);
 
-        // Wake all villagers before shutdown so they aren't left lobotomized forever if the plugin is removed
         // Take a snapshot of the union under stateLock — covers any villager stuck in both sets.
         // Cancel and clear per-villager tasks under the same lock that scheduleVillagerTask holds, so a
         // concurrent schedule can't install an orphan task after we clear (it re-checks shuttingDown there).

--- a/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
@@ -14,7 +14,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
-import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -139,13 +138,17 @@ public final class UninstallSweep {
             }
             this.dispatched.incrementAndGet();
             try {
-                villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> {
+                ScheduledTask scheduled = villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> {
                     try {
                         restore(villager);
                     } finally {
                         this.completed.incrementAndGet();
                     }
                 }), this.completed::incrementAndGet);
+                if (scheduled == null) {
+                    // Entity already gone, so neither callback will fire; do not wait on it.
+                    this.completed.incrementAndGet();
+                }
             } catch (Exception e) {
                 this.completed.incrementAndGet();
                 this.plugin.getLogger().log(Level.WARNING,

--- a/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
@@ -417,8 +417,9 @@ public final class UninstallSweep {
                 report(Component.text(this.unresolvedCount + " villager(s) could not be found and were dropped.")
                         .color(NamedTextColor.YELLOW));
             }
-            report(Component.text("Uninstall incomplete, so the state file was kept. "
-                    + "Run '/lobotomy uninstall confirm' again to finish.").color(NamedTextColor.YELLOW));
+            report(Component.text("Uninstall incomplete, so the state file was kept. No villagers are "
+                    + "being tracked until the server restarts: run '/lobotomy uninstall confirm' again to "
+                    + "finish, or restart to resume normal operation.").color(NamedTextColor.YELLOW));
         }
 
         ScheduledTask task = this.pumpTask;

--- a/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
@@ -117,6 +117,7 @@ public final class UninstallSweep {
         long now = System.currentTimeMillis();
         this.phaseADeadline = now + PHASE_A_TIMEOUT_MILLIS;
         this.lastChangeAt = now;
+        this.lastProgressAt = now;
         this.pumpTask = Bukkit.getGlobalRegionScheduler().runAtFixedRate(
                 this.plugin, SentryTaskWrapper.wrap((task) -> pump()), 1L, 1L);
     }
@@ -185,23 +186,27 @@ public final class UninstallSweep {
         if (!done && System.currentTimeMillis() < this.phaseADeadline) {
             return;
         }
+
         // Anything still outstanding is picked up by the row sweep; restore() is idempotent.
+        // Reading the table blocks briefly, which is fine here: it is one small local query during an
+        // operation the admin asked for that is about to force-load chunks anyway.
         this.store.drainNow();
-        buildTargets();
+        buildTargets(readRows());
         this.stage = Stage.SWEEPING_ROWS;
     }
 
-    /** Groups remaining rows by chunk, so a whole trading hall costs one chunk load. */
-    private void buildTargets() {
-        List<MarkedVillager> rows;
+    private @NotNull List<MarkedVillager> readRows() {
         try {
-            rows = this.store.loadAll();
+            return this.store.loadAll();
         } catch (SQLException e) {
             this.plugin.getLogger().log(Level.SEVERE, "Could not read the marker store; "
                     + "villagers in unloaded chunks were not restored.", e);
-            rows = List.of();
+            return List.of();
         }
+    }
 
+    /** Groups remaining rows by chunk, so a whole trading hall costs one chunk load. */
+    private void buildTargets(@NotNull List<MarkedVillager> rows) {
         Map<Long, ChunkTarget> byChunk = new HashMap<>();
         for (MarkedVillager row : rows) {
             if (this.cleared.contains(row.entityId())) {

--- a/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/UninstallSweep.java
@@ -1,0 +1,479 @@
+package dev.mja00.villagerLobotomizer;
+
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
+import dev.mja00.villagerLobotomizer.storage.MarkedVillager;
+import dev.mja00.villagerLobotomizer.utils.SentryTaskWrapper;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.sql.SQLException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
+/**
+ * Undoes everything the plugin has done: restores AI and strips the persistent marker from every
+ * villager it ever lobotomized, including those in chunks that are not loaded, then disables the
+ * plugin so the jar can be deleted.
+ *
+ * <p>Runs as a small state machine driven from the global region scheduler. Villagers currently in
+ * memory are handled first, then the remaining rows in the marker store drive targeted chunk loads.
+ */
+public final class UninstallSweep {
+
+    /**
+     * Brings a chunk into memory and hands it to the callback on a thread that owns it. Injectable
+     * because MockBukkit does not implement asynchronous chunk loading.
+     */
+    @FunctionalInterface
+    public interface ChunkAccessor {
+        void withChunk(World world, int chunkX, int chunkZ, Consumer<@Nullable Chunk> callback);
+    }
+
+    /** Roughly one player's view-distance stream, so the sweep never looks like a load storm. */
+    private static final int MAX_IN_FLIGHT = 8;
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long PROGRESS_EVERY_TICKS = 100L;
+    private static final long PHASE_A_TIMEOUT_MILLIS = 10_000L;
+    private static final long STALL_TIMEOUT_MILLIS = 30_000L;
+
+    private enum Stage { RESTORING_LOADED, SWEEPING_ROWS, FINISHED }
+
+    private final VillagerLobotomizer plugin;
+    private final LobotomizedMarkerStore store;
+    private final NamespacedKey lobotomizedKey;
+    private final boolean silent;
+    private final UUID requesterId;
+    private final ChunkAccessor chunkAccessor;
+
+    private final AtomicInteger dispatched = new AtomicInteger();
+    private final AtomicInteger completed = new AtomicInteger();
+    private final AtomicInteger restored = new AtomicInteger();
+    private final AtomicInteger chunksSwept = new AtomicInteger();
+    private final AtomicInteger inFlight = new AtomicInteger();
+
+    private final Set<UUID> cleared = ConcurrentHashMap.newKeySet();
+    /** Rows in worlds that are not loaded right now. Kept, never dropped. */
+    private final Set<UUID> skippedIds = ConcurrentHashMap.newKeySet();
+    private final Map<UUID, MarkedVillager> rowsById = new HashMap<>();
+    private final Deque<ChunkTarget> queue = new ArrayDeque<>();
+
+    private Stage stage = Stage.RESTORING_LOADED;
+    private ScheduledTask pumpTask;
+    private long phaseADeadline;
+    private long lastProgressAt;
+    private int totalChunks;
+    private int lastSweptSeen;
+    private long lastChangeAt;
+    private boolean secondPassDone;
+    private int unresolvedCount;
+
+    UninstallSweep(@NotNull VillagerLobotomizer plugin, @NotNull LobotomizedMarkerStore store,
+                   @Nullable UUID requesterId, @NotNull ChunkAccessor chunkAccessor) {
+        this.plugin = plugin;
+        this.store = store;
+        this.lobotomizedKey = new NamespacedKey(plugin, LobotomizeStorage.LOBOTOMIZED_KEY);
+        this.silent = plugin.getConfig().getBoolean("silent-lobotomized-villagers");
+        this.requesterId = requesterId;
+        this.chunkAccessor = chunkAccessor;
+    }
+
+    static @NotNull ChunkAccessor paperChunkAccessor() {
+        // The consumer overload is always invoked by the chunk system on a thread that owns the chunk;
+        // the CompletableFuture form can complete inline on the calling thread instead.
+        // generate=false so an ungenerated chunk yields null rather than creating terrain.
+        return (world, chunkX, chunkZ, callback) -> world.getChunkAtAsync(chunkX, chunkZ, false, callback);
+    }
+
+    /** Quiesces the plugin, restores everything in memory, then starts the row-driven sweep. */
+    void start() {
+        List<Villager> tracked = this.plugin.getStorage().quiesceForUninstall();
+        report(Component.text("Restoring villagers, this may take a while on a large world.")
+                .color(NamedTextColor.YELLOW));
+
+        restoreLoadedVillagers(tracked);
+
+        long now = System.currentTimeMillis();
+        this.phaseADeadline = now + PHASE_A_TIMEOUT_MILLIS;
+        this.lastChangeAt = now;
+        this.pumpTask = Bukkit.getGlobalRegionScheduler().runAtFixedRate(
+                this.plugin, SentryTaskWrapper.wrap((task) -> pump()), 1L, 1L);
+    }
+
+    /**
+     * Restores every villager currently in memory. Also scans loaded worlds, so a villager whose row
+     * was never written is still cleaned up.
+     */
+    private void restoreLoadedVillagers(@NotNull List<Villager> tracked) {
+        Set<UUID> seen = new HashSet<>();
+        List<Villager> candidates = new ArrayList<>(tracked);
+        for (World world : Bukkit.getWorlds()) {
+            candidates.addAll(world.getEntitiesByClass(Villager.class));
+        }
+
+        for (Villager villager : candidates) {
+            if (!seen.add(villager.getUniqueId())) {
+                continue;
+            }
+            this.dispatched.incrementAndGet();
+            try {
+                villager.getScheduler().run(this.plugin, SentryTaskWrapper.wrap((task) -> {
+                    try {
+                        restore(villager);
+                    } finally {
+                        this.completed.incrementAndGet();
+                    }
+                }), this.completed::incrementAndGet);
+            } catch (Exception e) {
+                this.completed.incrementAndGet();
+                this.plugin.getLogger().log(Level.WARNING,
+                        "Could not restore villager " + villager.getUniqueId(), e);
+            }
+        }
+    }
+
+    /**
+     * The one idempotent unit of work, always on the thread that owns the entity. The row is dropped
+     * last: doing it before the marker is actually gone would leave a marker nothing records.
+     */
+    private void restore(@NotNull Villager villager) {
+        villager.setAware(true);
+        if (this.silent) {
+            villager.setSilent(false);
+        }
+        villager.getPersistentDataContainer().remove(this.lobotomizedKey);
+        this.cleared.add(villager.getUniqueId());
+        this.store.markerCleared(villager.getUniqueId());
+        this.restored.incrementAndGet();
+    }
+
+    private void pump() {
+        switch (this.stage) {
+            case RESTORING_LOADED -> pumpRestoringLoaded();
+            case SWEEPING_ROWS -> pumpSweepingRows();
+            case FINISHED -> { }
+        }
+    }
+
+    private void pumpRestoringLoaded() {
+        boolean done = this.completed.get() >= this.dispatched.get();
+        if (!done && System.currentTimeMillis() < this.phaseADeadline) {
+            return;
+        }
+        // Anything still outstanding is picked up by the row sweep; restore() is idempotent.
+        this.store.drainNow();
+        buildTargets();
+        this.stage = Stage.SWEEPING_ROWS;
+    }
+
+    /** Groups remaining rows by chunk, so a whole trading hall costs one chunk load. */
+    private void buildTargets() {
+        List<MarkedVillager> rows;
+        try {
+            rows = this.store.loadAll();
+        } catch (SQLException e) {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not read the marker store; "
+                    + "villagers in unloaded chunks were not restored.", e);
+            rows = List.of();
+        }
+
+        Map<Long, ChunkTarget> byChunk = new HashMap<>();
+        for (MarkedVillager row : rows) {
+            if (this.cleared.contains(row.entityId())) {
+                continue;
+            }
+            World world = Bukkit.getWorld(row.worldId());
+            if (world == null) {
+                // Not a missing world, just one that is not loaded right now. Keep the row so the
+                // command can finish the job once it is.
+                this.skippedIds.add(row.entityId());
+                continue;
+            }
+            this.rowsById.put(row.entityId(), row);
+            byChunk.computeIfAbsent(Chunk.getChunkKey(row.chunkX(), row.chunkZ()),
+                    (key) -> new ChunkTarget(world, row.chunkX(), row.chunkZ())).villagerIds.add(row.entityId());
+        }
+
+        this.queue.addAll(byChunk.values());
+        this.totalChunks = this.queue.size();
+        if (this.totalChunks > 0) {
+            report(Component.text("Loading " + this.totalChunks + " chunk(s) to reach villagers that are not in memory."));
+        }
+    }
+
+    private void pumpSweepingRows() {
+        while (this.inFlight.get() < MAX_IN_FLIGHT) {
+            ChunkTarget target = this.queue.poll();
+            if (target == null) {
+                break;
+            }
+            this.inFlight.incrementAndGet();
+            requestChunk(target);
+        }
+
+        reportProgress();
+
+        if (!this.queue.isEmpty() || this.inFlight.get() > 0) {
+            checkForStall();
+            return;
+        }
+        if (!this.secondPassDone) {
+            this.secondPassDone = true;
+            buildSecondPassTargets();
+            if (!this.queue.isEmpty()) {
+                return;
+            }
+        }
+        finish(true);
+    }
+
+    private void requestChunk(@NotNull ChunkTarget target) {
+        try {
+            this.chunkAccessor.withChunk(target.world, target.chunkX, target.chunkZ, (chunk) -> {
+                try {
+                    if (chunk == null) {
+                        // generate=false and nothing on disk. Leave these outstanding: the second pass
+                        // may still find them in a neighbouring chunk.
+                        return;
+                    }
+                    if (Bukkit.isOwnedByCurrentRegion(target.world, target.chunkX, target.chunkZ)) {
+                        sweepChunk(target, chunk);
+                        return;
+                    }
+                    // Folia's thread confinement for this callback is undocumented, so hand off to the
+                    // scheduler that is documented to own the chunk rather than assume.
+                    Bukkit.getRegionScheduler().execute(this.plugin, target.world, target.chunkX, target.chunkZ, () -> {
+                        if (!target.world.isChunkLoaded(target.chunkX, target.chunkZ)) {
+                            requeue(target);
+                            return;
+                        }
+                        sweepChunk(target, target.world.getChunkAt(target.chunkX, target.chunkZ));
+                    });
+                } finally {
+                    this.inFlight.decrementAndGet();
+                }
+            });
+        } catch (Exception e) {
+            this.inFlight.decrementAndGet();
+            this.plugin.getLogger().log(Level.WARNING, "Could not load chunk "
+                    + target.chunkX + "," + target.chunkZ + " in " + target.world.getName(), e);
+        }
+    }
+
+    private void sweepChunk(@NotNull ChunkTarget target, @NotNull Chunk chunk) {
+        if (!chunk.isEntitiesLoaded()) {
+            // getEntities() returns an empty array until the entity sections load, which would look
+            // like "no villagers here" and silently under-clean.
+            requeue(target);
+            return;
+        }
+
+        Set<UUID> wanted = new HashSet<>(target.villagerIds);
+        for (Entity entity : chunk.getEntities()) {
+            if (entity instanceof Villager villager && wanted.remove(villager.getUniqueId())) {
+                restore(villager);
+            }
+        }
+        this.chunksSwept.incrementAndGet();
+        this.lastChangeAt = System.currentTimeMillis();
+    }
+
+    private void requeue(@NotNull ChunkTarget target) {
+        if (++target.attempts >= MAX_ATTEMPTS) {
+            // Out of retries; whatever is still outstanding is reported at the end.
+            return;
+        }
+        Bukkit.getGlobalRegionScheduler().execute(this.plugin, () -> this.queue.add(target));
+    }
+
+    /** Retries the 3x3 neighbourhood for villagers that were not in their recorded chunk. */
+    private void buildSecondPassTargets() {
+        Set<UUID> stillMissing = outstanding();
+        if (stillMissing.isEmpty()) {
+            return;
+        }
+
+        Map<Long, ChunkTarget> byChunk = new HashMap<>();
+        for (UUID entityId : stillMissing) {
+            MarkedVillager row = this.rowsById.get(entityId);
+            if (row == null) {
+                continue;
+            }
+            World world = Bukkit.getWorld(row.worldId());
+            if (world == null) {
+                continue;
+            }
+            for (int dx = -1; dx <= 1; dx++) {
+                for (int dz = -1; dz <= 1; dz++) {
+                    int chunkX = row.chunkX() + dx;
+                    int chunkZ = row.chunkZ() + dz;
+                    byChunk.computeIfAbsent(Chunk.getChunkKey(chunkX, chunkZ),
+                            (key) -> new ChunkTarget(world, chunkX, chunkZ)).villagerIds.add(entityId);
+                }
+            }
+        }
+        this.queue.addAll(byChunk.values());
+        this.totalChunks += this.queue.size();
+    }
+
+    /** Rows we meant to visit that are still neither restored nor skipped. */
+    private @NotNull Set<UUID> outstanding() {
+        Set<UUID> remaining = new HashSet<>(this.rowsById.keySet());
+        remaining.removeAll(this.cleared);
+        return remaining;
+    }
+
+    private void checkForStall() {
+        int swept = this.chunksSwept.get();
+        if (swept != this.lastSweptSeen) {
+            this.lastSweptSeen = swept;
+            this.lastChangeAt = System.currentTimeMillis();
+            return;
+        }
+        if (System.currentTimeMillis() - this.lastChangeAt > STALL_TIMEOUT_MILLIS) {
+            this.plugin.getLogger().warning("Uninstall stalled waiting on chunk loads; stopping here.");
+            finish(false);
+        }
+    }
+
+    private void reportProgress() {
+        long now = System.currentTimeMillis();
+        if (now - this.lastProgressAt < PROGRESS_EVERY_TICKS * 50L) {
+            return;
+        }
+        this.lastProgressAt = now;
+        if (this.totalChunks == 0) {
+            return;
+        }
+        report(Component.text("Restored " + this.restored.get() + " villager(s), "
+                + this.chunksSwept.get() + "/" + this.totalChunks + " chunks."));
+    }
+
+    /**
+     * Deletes only the rows actually cleared. The state file is kept whenever anything was skipped or
+     * unresolved, so re-running the command can finish rather than leaving villagers with no record.
+     */
+    private void finish(boolean completedNormally) {
+        this.stage = Stage.FINISHED;
+        // Whatever is left could not be found: dead, converted, or its region file is gone. Drop the
+        // rows so a re-run does not chase them forever, but report how many.
+        Set<UUID> unresolvedIds = outstanding();
+        this.unresolvedCount = unresolvedIds.size();
+        this.cleared.addAll(unresolvedIds);
+
+        try {
+            this.store.deleteNow(this.cleared);
+        } catch (SQLException e) {
+            this.plugin.getLogger().log(Level.WARNING, "Could not delete restored villagers from the marker store.", e);
+        }
+        this.store.drainNow();
+
+        int outstanding = this.skippedIds.size() + this.unresolvedCount;
+        boolean clean = completedNormally && outstanding == 0;
+
+        report(Component.text("Restored ").append(Component.text(this.restored.get()).color(NamedTextColor.GREEN))
+                .append(Component.text(" villager(s) across " + this.chunksSwept.get() + " chunk(s).")));
+
+        if (clean) {
+            this.store.deleteDatabaseFiles();
+            report(Component.text("Uninstall complete. It is safe to delete the plugin jar now; "
+                    + "restart the server to finish removing it.").color(NamedTextColor.GREEN));
+        } else {
+            if (this.skippedIds.size() > 0) {
+                report(Component.text(this.skippedIds.size() + " villager(s) are in worlds that are not loaded.")
+                        .color(NamedTextColor.YELLOW));
+            }
+            if (this.unresolvedCount > 0) {
+                report(Component.text(this.unresolvedCount + " villager(s) could not be found and were dropped.")
+                        .color(NamedTextColor.YELLOW));
+            }
+            report(Component.text("Uninstall incomplete, so the state file was kept. "
+                    + "Run '/lobotomy uninstall confirm' again to finish.").color(NamedTextColor.YELLOW));
+        }
+
+        ScheduledTask task = this.pumpTask;
+        this.pumpTask = null;
+        if (task != null) {
+            try {
+                task.cancel();
+            } catch (Throwable t) {
+                // Harmless: the pump no-ops once the stage is FINISHED.
+            }
+        }
+
+        if (!clean) {
+            // Leave the plugin enabled so the command is still there to re-run.
+            this.plugin.finishUninstall(false);
+            return;
+        }
+        this.plugin.finishUninstall(true);
+    }
+
+    private void report(@NotNull Component message) {
+        this.plugin.getLogger().info(PlainTextComponentSerializer.plainText().serialize(message));
+        if (this.requesterId == null) {
+            return;
+        }
+        Player player = Bukkit.getPlayer(this.requesterId);
+        if (player != null) {
+            player.sendMessage(message);
+        }
+    }
+
+    /** Test hook: drives the state machine without the scheduler. */
+    void pumpForTesting() {
+        pump();
+    }
+
+    int getRestoredCount() {
+        return this.restored.get();
+    }
+
+    int getUnresolvedCount() {
+        return this.unresolvedCount;
+    }
+
+    int getSkippedCount() {
+        return this.skippedIds.size();
+    }
+
+    boolean isFinished() {
+        return this.stage == Stage.FINISHED;
+    }
+
+    private static final class ChunkTarget {
+        private final World world;
+        private final int chunkX;
+        private final int chunkZ;
+        private final List<UUID> villagerIds = new ArrayList<>();
+        private int attempts;
+
+        private ChunkTarget(World world, int chunkX, int chunkZ) {
+            this.world = world;
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
+        }
+    }
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -3,8 +3,10 @@ package dev.mja00.villagerLobotomizer;
 import com.google.gson.Gson;
 import dev.mja00.villagerLobotomizer.listeners.EntityListener;
 import dev.mja00.villagerLobotomizer.objects.Modrinth;
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
 import dev.mja00.villagerLobotomizer.utils.ConfigMigrator;
 import dev.mja00.villagerLobotomizer.utils.SentryContextProvider;
+import dev.mja00.villagerLobotomizer.utils.SentryTaskWrapper;
 import dev.mja00.villagerLobotomizer.utils.VersionUtils;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import io.sentry.Sentry;
@@ -15,7 +17,9 @@ import org.bstats.charts.MultiLineChart;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -31,6 +35,7 @@ import java.net.http.HttpResponse;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeUnit;
 
 public class VillagerLobotomizer extends JavaPlugin {
@@ -47,7 +52,11 @@ public class VillagerLobotomizer extends JavaPlugin {
     private final String activeVillagersTeamName = "lobotomy_active_villagers";
     private final String inactiveVillagersTeamName = "lobotomy_inactive_villagers";
     private boolean disableChunkVillagerUpdate;
+    /** How often buffered marker changes are written; short enough that a crash loses little. */
+    private static final long MARKER_STORE_DRAIN_SECONDS = 5L;
     private boolean sentryEnabled = false;
+    private LobotomizedMarkerStore markerStore;
+    private final AtomicBoolean uninstalling = new AtomicBoolean();
 
     /**
      * Initializes the plugin, loading configuration, storage, listeners, commands, and debug features.
@@ -56,6 +65,7 @@ public class VillagerLobotomizer extends JavaPlugin {
     public void onEnable() {
         ConfigMigrator migrator = new ConfigMigrator(this);
         migrator.migrateConfig();
+        this.openMarkerStore();
         boolean disableUpdateCheck = this.getConfig().getBoolean("disable-update-checker", false);
         if (!disableUpdateCheck) {
             this.checkForUpdates();
@@ -206,6 +216,10 @@ public class VillagerLobotomizer extends JavaPlugin {
         if (this.storage != null) {
             this.storage.flush();
         }
+        if (this.markerStore != null) {
+            // Drains before closing, so the last few marker changes are not lost.
+            this.markerStore.close();
+        }
         // No need to cancel tasks manually - Paper handles this automatically on disable
         // Clean up debug teams (non-Folia only)
         if (!this.isFolia) {
@@ -230,6 +244,79 @@ public class VillagerLobotomizer extends JavaPlugin {
                 this.getLogger().log(java.util.logging.Level.WARNING, "Error during Sentry shutdown: " + e.getMessage(), e);
             }
         }
+    }
+
+    /**
+     * Opens the marker store when persistence is enabled. A failure is not fatal: storage forces
+     * persistence off for the session so no marker is written that the uninstall sweep could not find.
+     */
+    private void openMarkerStore() {
+        if (!this.getConfig().getBoolean("persist-lobotomized-state", true)) {
+            return;
+        }
+        LobotomizedMarkerStore store = new LobotomizedMarkerStore(
+                this.getDataFolder().toPath().resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME), this.getLogger());
+        if (!store.open()) {
+            return;
+        }
+        store.startDrainTask(this, MARKER_STORE_DRAIN_SECONDS);
+        this.markerStore = store;
+        this.getLogger().info("Lobotomized villagers stay lobotomized across restarts. "
+                + "Run '/lobotomy uninstall' before removing the plugin so they get their AI back.");
+    }
+
+    /**
+     * @return the marker store, or {@code null} when persistence is disabled or unavailable
+     */
+    public LobotomizedMarkerStore getMarkerStore() {
+        return this.markerStore;
+    }
+
+    public boolean isUninstalling() {
+        return this.uninstalling.get();
+    }
+
+    /**
+     * Starts the one-shot uninstall sweep: restores every villager the plugin has lobotomized and,
+     * when nothing is left outstanding, disables the plugin.
+     *
+     * @param requester who asked, for progress messages; console messages go to the log
+     * @return {@code false} when a sweep is already running or could not be started
+     */
+    public boolean startUninstall(CommandSender requester) {
+        if (!this.uninstalling.compareAndSet(false, true)) {
+            return false;
+        }
+
+        // An unopened store is a safe no-op stand-in: persistence may be off, in which case there are
+        // no rows to sweep and restoring the loaded villagers is the whole job.
+        LobotomizedMarkerStore store = this.markerStore != null ? this.markerStore
+                : new LobotomizedMarkerStore(
+                        this.getDataFolder().toPath().resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME),
+                        this.getLogger());
+        try {
+            new UninstallSweep(this, store, requester instanceof Player player ? player.getUniqueId() : null,
+                    UninstallSweep.paperChunkAccessor()).start();
+            return true;
+        } catch (Exception e) {
+            this.uninstalling.set(false);
+            this.getLogger().log(java.util.logging.Level.SEVERE, "Could not start the uninstall sweep.", e);
+            return false;
+        }
+    }
+
+    /**
+     * Called by the sweep when it stops. An incomplete run stays enabled so the command can be
+     * re-run; a clean one disables a tick later, once the sweep's own task has been cancelled.
+     */
+    void finishUninstall(boolean cleanedEverything) {
+        if (!cleanedEverything) {
+            this.uninstalling.set(false);
+            return;
+        }
+        this.markerStore = null;
+        Bukkit.getGlobalRegionScheduler().runDelayed(this,
+                SentryTaskWrapper.wrap((task) -> Bukkit.getPluginManager().disablePlugin(this)), 1L);
     }
 
     /**
@@ -486,6 +573,12 @@ public class VillagerLobotomizer extends JavaPlugin {
      * @return the number of villagers added to storage, or -1 if storage recreation fails
      */
     public int reloadPluginState() {
+        if (this.uninstalling.get()) {
+            // A reload would build a fresh storage and re-lobotomize villagers the sweep is clearing,
+            // leaving markers behind with no state file to find them by.
+            this.getLogger().warning("Refusing to reload while an uninstall is in progress.");
+            return -1;
+        }
         this.reloadConfig();
         // Apply enable-sentry transitions on reload (init if newly enabled, close if newly disabled).
         this.applySentryConfig();

--- a/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/VillagerLobotomizer.java
@@ -214,7 +214,7 @@ public class VillagerLobotomizer extends JavaPlugin {
     public void onDisable() {
         getLogger().info("Man guess I'll put my tools away now :(");
         if (this.storage != null) {
-            this.storage.flush();
+            this.storage.flush(LobotomizeStorage.FlushMode.SHUTDOWN);
         }
         if (this.markerStore != null) {
             // Drains before closing, so the last few marker changes are not lost.
@@ -602,7 +602,7 @@ public class VillagerLobotomizer extends JavaPlugin {
 
         if (previousStorage != null) {
             // Reload: plugin stays enabled, so dispatch wake work via the entity scheduler (Folia-safe).
-            previousStorage.flush(true);
+            previousStorage.flush(LobotomizeStorage.FlushMode.RELOAD);
         }
         this.storage = newStorage;
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/listeners/EntityListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityRemoveEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
@@ -21,6 +22,7 @@ import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 
 import dev.mja00.villagerLobotomizer.VillagerLobotomizer;
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
@@ -81,6 +83,23 @@ public class EntityListener implements Listener {
             if (this.plugin.isDebugging()) {
                 this.plugin.getLogger().log(Level.INFO, "[Debug] Caught {0} for villager {1} ({2}); The villager should have been removed from the storage", new Object[]{event.getEventName(), event.getEntity(), event.getEntity().getUniqueId()});
             }
+        }
+    }
+
+    /**
+     * Drops the tracking row when the villager itself is gone. {@code isDead()} and {@code isValid()}
+     * are both false for a merely unloaded entity, so the removal cause is the only reliable signal
+     * that the marker died with it. Unloads must keep their row, or the state survives on disk with
+     * nothing recording where to find it.
+     */
+    @EventHandler
+    public final void onEntityRemove(EntityRemoveEvent event) {
+        if (event.getCause() == EntityRemoveEvent.Cause.UNLOAD || !(event.getEntity() instanceof Villager villager)) {
+            return;
+        }
+        LobotomizedMarkerStore store = this.plugin.getMarkerStore();
+        if (store != null) {
+            store.markerCleared(villager.getUniqueId());
         }
     }
 

--- a/src/main/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStore.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStore.java
@@ -1,0 +1,435 @@
+package dev.mja00.villagerLobotomizer.storage;
+
+import dev.mja00.villagerLobotomizer.utils.SentryTaskWrapper;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Villager;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.sqlite.SQLiteDataSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Records which villagers currently carry the persistent lobotomy marker, so
+ * {@code /lobotomy uninstall} can find them again even when their chunks are not loaded.
+ *
+ * <p>The invariant is that a row exists exactly when the plugin has written the PDC marker on that
+ * villager. Callers announce marker changes via {@link #markerWritten} and {@link #markerCleared},
+ * which only touch memory; the rows are written by {@link #drainNow()} on an async task.
+ *
+ * <p>Deliberately free of Bukkit types except for {@link #startDrainTask} and the {@link Villager}
+ * convenience overload, so the persistence logic is unit-testable without a server.
+ */
+public final class LobotomizedMarkerStore implements AutoCloseable {
+
+    public static final String DATABASE_FILE_NAME = "state.db";
+
+    /** Consecutive drain failures after which we stop writing rather than retry forever. */
+    private static final int MAX_CONSECUTIVE_FAILURES = 5;
+
+    private static final String CREATE_TABLE = """
+            CREATE TABLE IF NOT EXISTS marked_villagers (
+                entity_uuid TEXT    NOT NULL PRIMARY KEY,
+                world_uuid  TEXT    NOT NULL,
+                chunk_x     INTEGER NOT NULL,
+                chunk_z     INTEGER NOT NULL
+            ) WITHOUT ROWID
+            """;
+    private static final String UPSERT_ROW = """
+            INSERT INTO marked_villagers (entity_uuid, world_uuid, chunk_x, chunk_z)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(entity_uuid) DO UPDATE SET
+                world_uuid = excluded.world_uuid,
+                chunk_x = excluded.chunk_x,
+                chunk_z = excluded.chunk_z
+            """;
+    private static final String DELETE_ROW = "DELETE FROM marked_villagers WHERE entity_uuid = ?";
+    private static final String SELECT_ALL = "SELECT entity_uuid, world_uuid, chunk_x, chunk_z FROM marked_villagers";
+
+    private final Path databaseFile;
+    private final Logger logger;
+    private final Object ioLock = new Object();
+
+    /**
+     * What the plugin intends the table to contain, keyed by entity UUID. Updated by the announcing
+     * thread so it can never disagree with the PDC writes it mirrors. Entries are either committed
+     * rows, pending upserts, or pending deletes; committed deletes are removed outright.
+     */
+    private final Map<UUID, Intent> intents = new ConcurrentHashMap<>();
+
+    private Connection connection;
+    private ScheduledTask drainTask;
+    private volatile boolean usable;
+    private volatile boolean closed;
+    private int consecutiveFailures;
+
+    public LobotomizedMarkerStore(@NotNull Path databaseFile, @NotNull Logger logger) {
+        this.databaseFile = databaseFile;
+        this.logger = logger;
+    }
+
+    /**
+     * Opens the database, applies the schema and seeds the intent map from existing rows.
+     *
+     * @return {@code false} if the store is unusable, in which case callers must not write markers
+     */
+    public boolean open() {
+        synchronized (this.ioLock) {
+            try {
+                Path parent = this.databaseFile.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+
+                SQLiteDataSource dataSource = new SQLiteDataSource();
+                dataSource.setUrl("jdbc:sqlite:" + this.databaseFile.toAbsolutePath());
+                this.connection = dataSource.getConnection();
+                applyPragmas(this.connection);
+
+                try (Statement statement = this.connection.createStatement()) {
+                    statement.executeUpdate(CREATE_TABLE);
+                    statement.executeUpdate("PRAGMA user_version = 1");
+                }
+
+                for (MarkedVillager row : readAll(this.connection)) {
+                    this.intents.put(row.entityId(), Intent.committed(row.worldId(), row.chunkX(), row.chunkZ()));
+                }
+
+                this.usable = true;
+                return true;
+            } catch (SQLException | IOException | RuntimeException e) {
+                this.logger.log(Level.SEVERE, "Could not open " + this.databaseFile
+                        + "; lobotomized state will not persist this session.", e);
+                closeConnectionQuietly();
+                this.usable = false;
+                return false;
+            }
+        }
+    }
+
+    private void applyPragmas(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            // Some network and container mounts cannot provide WAL's shared memory, so fall back to
+            // the rollback journal instead of failing outright.
+            try (ResultSet results = statement.executeQuery("PRAGMA journal_mode = WAL")) {
+                String mode = results.next() ? results.getString(1) : null;
+                if (mode != null && !"wal".equalsIgnoreCase(mode)) {
+                    this.logger.warning("SQLite refused WAL mode on this filesystem (got " + mode
+                            + "); continuing with the default journal.");
+                }
+            }
+            statement.execute("PRAGMA synchronous = NORMAL");
+            statement.execute("PRAGMA busy_timeout = 3000");
+        }
+    }
+
+    public boolean isUsable() {
+        return this.usable && !this.closed;
+    }
+
+    /**
+     * Starts the periodic async drain. Separate from {@link #open()} so tests can drain on demand.
+     */
+    public void startDrainTask(@NotNull Plugin plugin, long periodSeconds) {
+        if (!isUsable()) {
+            return;
+        }
+        this.drainTask = Bukkit.getAsyncScheduler().runAtFixedRate(plugin,
+                SentryTaskWrapper.wrap((task) -> drainNow()), periodSeconds, periodSeconds, TimeUnit.SECONDS);
+    }
+
+    /** Records that the marker now exists on this villager. Never does I/O. */
+    public void markerWritten(@NotNull UUID entityId, @NotNull UUID worldId, int chunkX, int chunkZ) {
+        if (!isUsable()) {
+            return;
+        }
+        this.intents.compute(entityId, (id, current) -> {
+            if (current != null && current.matches(worldId, chunkX, chunkZ) && !current.dirty()) {
+                return current;
+            }
+            return Intent.pendingUpsert(worldId, chunkX, chunkZ);
+        });
+    }
+
+    /**
+     * Records that the marker now exists, deriving the chunk from the villager. Must be called on the
+     * thread that owns the entity.
+     */
+    public void markerWritten(@NotNull Villager villager) {
+        markerWritten(villager.getUniqueId(), villager.getWorld().getUID(),
+                villager.getLocation().getBlockX() >> 4, villager.getLocation().getBlockZ() >> 4);
+    }
+
+    /**
+     * Records that the marker is gone. A villager we hold no row for is a no-op, which is what keeps
+     * the per-check marker clearing on active villagers from queueing a delete every tick.
+     */
+    public void markerCleared(@NotNull UUID entityId) {
+        if (!isUsable()) {
+            return;
+        }
+        this.intents.compute(entityId, (id, current) -> {
+            if (current == null || current.absent()) {
+                return current;
+            }
+            return Intent.pendingDelete();
+        });
+    }
+
+    /** Rows the store believes exist, from memory. */
+    public int getKnownRowCount() {
+        return (int) this.intents.values().stream().filter((intent) -> !intent.absent()).count();
+    }
+
+    /** Applies every buffered change on the calling thread. Must not be called on a region thread. */
+    public void drainNow() {
+        if (!isUsable()) {
+            return;
+        }
+
+        Map<UUID, Intent> batch = new HashMap<>();
+        this.intents.forEach((id, intent) -> {
+            if (intent.dirty()) {
+                batch.put(id, intent);
+            }
+        });
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        synchronized (this.ioLock) {
+            if (this.closed || this.connection == null) {
+                return;
+            }
+            try {
+                applyBatch(batch);
+                this.consecutiveFailures = 0;
+            } catch (SQLException e) {
+                this.consecutiveFailures++;
+                // Leave the entries dirty so the next drain retries them.
+                if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                    this.usable = false;
+                    this.logger.log(Level.SEVERE, "Giving up on " + this.databaseFile + " after "
+                            + this.consecutiveFailures + " failed writes; lobotomized state will not persist.", e);
+                } else {
+                    this.logger.log(Level.WARNING, "Failed to write lobotomy state; will retry.", e);
+                }
+                return;
+            }
+        }
+
+        // Mark clean only where nothing changed underneath us, so a concurrent update stays dirty.
+        batch.forEach((id, applied) -> this.intents.compute(id, (key, current) -> {
+            if (current != applied) {
+                return current;
+            }
+            return current.absent() ? null : current.asCommitted();
+        }));
+    }
+
+    private void applyBatch(Map<UUID, Intent> batch) throws SQLException {
+        boolean previousAutoCommit = this.connection.getAutoCommit();
+        this.connection.setAutoCommit(false);
+        try (PreparedStatement upsert = this.connection.prepareStatement(UPSERT_ROW);
+             PreparedStatement delete = this.connection.prepareStatement(DELETE_ROW)) {
+            for (Map.Entry<UUID, Intent> entry : batch.entrySet()) {
+                Intent intent = entry.getValue();
+                if (intent.absent()) {
+                    delete.setString(1, entry.getKey().toString());
+                    delete.addBatch();
+                    continue;
+                }
+                upsert.setString(1, entry.getKey().toString());
+                upsert.setString(2, intent.worldId().toString());
+                upsert.setInt(3, intent.chunkX());
+                upsert.setInt(4, intent.chunkZ());
+                upsert.addBatch();
+            }
+            upsert.executeBatch();
+            delete.executeBatch();
+            this.connection.commit();
+        } catch (SQLException e) {
+            rollbackQuietly(e);
+            throw e;
+        } finally {
+            this.connection.setAutoCommit(previousAutoCommit);
+        }
+    }
+
+    public @NotNull List<MarkedVillager> loadAll() throws SQLException {
+        synchronized (this.ioLock) {
+            if (this.closed || this.connection == null) {
+                return List.of();
+            }
+            return readAll(this.connection);
+        }
+    }
+
+    /** Deletes rows immediately, bypassing the buffer. Used by the uninstall sweep. */
+    public void deleteNow(@NotNull Collection<UUID> entityIds) throws SQLException {
+        if (entityIds.isEmpty()) {
+            return;
+        }
+        synchronized (this.ioLock) {
+            if (this.closed || this.connection == null) {
+                return;
+            }
+            boolean previousAutoCommit = this.connection.getAutoCommit();
+            this.connection.setAutoCommit(false);
+            try (PreparedStatement delete = this.connection.prepareStatement(DELETE_ROW)) {
+                for (UUID entityId : entityIds) {
+                    delete.setString(1, entityId.toString());
+                    delete.addBatch();
+                }
+                delete.executeBatch();
+                this.connection.commit();
+            } catch (SQLException e) {
+                rollbackQuietly(e);
+                throw e;
+            } finally {
+                this.connection.setAutoCommit(previousAutoCommit);
+            }
+        }
+        entityIds.forEach(this.intents::remove);
+    }
+
+    private static @NotNull List<MarkedVillager> readAll(Connection connection) throws SQLException {
+        List<MarkedVillager> rows = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_ALL);
+             ResultSet results = statement.executeQuery()) {
+            while (results.next()) {
+                try {
+                    rows.add(new MarkedVillager(
+                            UUID.fromString(results.getString("entity_uuid")),
+                            UUID.fromString(results.getString("world_uuid")),
+                            results.getInt("chunk_x"),
+                            results.getInt("chunk_z")));
+                } catch (IllegalArgumentException e) {
+                    // A malformed UUID can only come from external editing; skip rather than abort.
+                }
+            }
+        }
+        return rows;
+    }
+
+    /** Drains, cancels the drain task and closes the connection. Idempotent. */
+    @Override
+    public void close() {
+        if (this.closed) {
+            return;
+        }
+        drainNow();
+        cancelDrainTask();
+        synchronized (this.ioLock) {
+            this.closed = true;
+            closeConnectionQuietly();
+        }
+    }
+
+    /**
+     * Closes without draining and deletes the database and its journal sidecars. Idempotent, and
+     * never reopens: a drain after this must not resurrect the file we just removed.
+     */
+    public boolean deleteDatabaseFiles() {
+        cancelDrainTask();
+        synchronized (this.ioLock) {
+            this.closed = true;
+            this.usable = false;
+            closeConnectionQuietly();
+            this.intents.clear();
+
+            boolean deleted = true;
+            for (String suffix : new String[]{"", "-wal", "-shm", "-journal"}) {
+                Path path = this.databaseFile.resolveSibling(this.databaseFile.getFileName() + suffix);
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    this.logger.log(Level.WARNING, "Could not delete " + path, e);
+                    deleted = false;
+                }
+            }
+            return deleted;
+        }
+    }
+
+    private void cancelDrainTask() {
+        ScheduledTask task = this.drainTask;
+        this.drainTask = null;
+        if (task == null) {
+            return;
+        }
+        try {
+            task.cancel();
+        } catch (Throwable t) {
+            // Cancellation failure is harmless; the task body no-ops once closed.
+        }
+    }
+
+    private void closeConnectionQuietly() {
+        Connection open = this.connection;
+        this.connection = null;
+        if (open == null) {
+            return;
+        }
+        try {
+            open.close();
+        } catch (SQLException e) {
+            this.logger.log(Level.WARNING, "Failed to close " + this.databaseFile, e);
+        }
+    }
+
+    private void rollbackQuietly(SQLException failure) {
+        try {
+            this.connection.rollback();
+        } catch (SQLException rollbackFailure) {
+            failure.addSuppressed(rollbackFailure);
+        }
+    }
+
+    /** Test hook: how many changes are waiting to be written. */
+    int pendingCount() {
+        return (int) this.intents.values().stream().filter(Intent::dirty).count();
+    }
+
+    private record Intent(UUID worldId, int chunkX, int chunkZ, boolean absent, boolean dirty) {
+
+        static Intent committed(UUID worldId, int chunkX, int chunkZ) {
+            return new Intent(worldId, chunkX, chunkZ, false, false);
+        }
+
+        static Intent pendingUpsert(UUID worldId, int chunkX, int chunkZ) {
+            return new Intent(worldId, chunkX, chunkZ, false, true);
+        }
+
+        static Intent pendingDelete() {
+            return new Intent(null, 0, 0, true, true);
+        }
+
+        boolean matches(UUID otherWorld, int otherChunkX, int otherChunkZ) {
+            return !this.absent && this.chunkX == otherChunkX && this.chunkZ == otherChunkZ
+                    && otherWorld.equals(this.worldId);
+        }
+
+        Intent asCommitted() {
+            return committed(this.worldId, this.chunkX, this.chunkZ);
+        }
+    }
+}

--- a/src/main/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStore.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStore.java
@@ -162,7 +162,8 @@ public final class LobotomizedMarkerStore implements AutoCloseable {
             return;
         }
         this.intents.compute(entityId, (id, current) -> {
-            if (current != null && current.matches(worldId, chunkX, chunkZ) && !current.dirty()) {
+            // Already recorded, or already queued with this same chunk: nothing to do either way.
+            if (current != null && current.matches(worldId, chunkX, chunkZ)) {
                 return current;
             }
             return Intent.pendingUpsert(worldId, chunkX, chunkZ);

--- a/src/main/java/dev/mja00/villagerLobotomizer/storage/MarkedVillager.java
+++ b/src/main/java/dev/mja00/villagerLobotomizer/storage/MarkedVillager.java
@@ -1,0 +1,14 @@
+package dev.mja00.villagerLobotomizer.storage;
+
+import java.util.UUID;
+
+/**
+ * A villager that carries the plugin's persistent lobotomy marker, and where to find it.
+ *
+ * @param entityId the villager's entity UUID
+ * @param worldId  the UUID of the world it was last seen in
+ * @param chunkX   chunk X it was last seen in
+ * @param chunkZ   chunk Z it was last seen in
+ */
+public record MarkedVillager(UUID entityId, UUID worldId, int chunkX, int chunkZ) {
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -68,8 +68,8 @@ prevent-trading-with-unlobotomized-villagers: false
 #Message that is sent to players when they try to trade with an unlobotomized villager. Supports MiniMessage.
 unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>"
 
-#Persist lobotomized state across chunk unloads. When enabled, villagers that are lobotomized will remain lobotomized when their chunk is unloaded and reloaded.
-#This prevents lag spikes from villagers needing to be re-evaluated and re-lobotomized after chunk loads.
+#Persist lobotomized state across chunk unloads and server restarts. When enabled, lobotomized villagers stay lobotomized, so there is no lag spike while they are re-evaluated after a chunk load or a reboot.
+#Run '/lobotomy uninstall' before removing the plugin. Deleting the jar on its own leaves those villagers without AI, because nothing is left to restore them.
 persist-lobotomized-state: true
 
 # ===== SENTRY ERROR TRACKING =====

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -16,6 +16,7 @@ permissions:
       lobotomy.command.wake: true
       lobotomy.command.reload: true
       lobotomy.command.config: true
+      lobotomy.command.uninstall: true
   lobotomy.command.info:
     description: "Allows viewing villager statistics"
     default: op
@@ -30,4 +31,7 @@ permissions:
     default: op
   lobotomy.command.config:
     description: "Allows viewing and modifying config values"
+    default: op
+  lobotomy.command.uninstall:
+    description: "Allows restoring every lobotomized villager and disabling the plugin"
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ permissions:
       lobotomy.command.wake: true
       lobotomy.command.reload: true
       lobotomy.command.config: true
+      lobotomy.command.uninstall: true
   lobotomy.command.info:
     description: "Allows viewing villager statistics"
     default: op
@@ -30,4 +31,7 @@ permissions:
     default: op
   lobotomy.command.config:
     description: "Allows viewing and modifying config values"
+    default: op
+  lobotomy.command.uninstall:
+    description: "Allows restoring every lobotomized villager and disabling the plugin"
     default: op

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageFlushTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageFlushTest.java
@@ -93,6 +93,20 @@ class LobotomizeStorageFlushTest extends MockBukkitTestBase {
     }
 
     @Test
+    void shutdownWakesVillagersWhenTheStoreDiedMidSession() {
+        load(true);
+        Villager villager = lobotomizedVillager();
+
+        // As the store looks after repeated write failures. Preserving state now would strand
+        // villagers with a marker but no row, which the uninstall sweep could never find.
+        plugin.getMarkerStore().close();
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.SHUTDOWN);
+
+        assertTrue(villager.isAware(), "an unusable store must fall back to waking villagers");
+        assertFalse(hasMarker(villager), "and leave no marker it cannot track");
+    }
+
+    @Test
     void reloadStillWakesAndClears() {
         load(true);
         Villager villager = lobotomizedVillager();

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageFlushTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageFlushTest.java
@@ -1,0 +1,130 @@
+package dev.mja00.villagerLobotomizer;
+
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What survives a shutdown. The reported bug was that nothing did: a nightly reboot woke every
+ * villager, so the lag spike came back each morning until check-interval elapsed.
+ */
+class LobotomizeStorageFlushTest extends MockBukkitTestBase {
+
+    /** Well under check-interval, so the periodic check (which mock blocks cannot evaluate) never runs. */
+    private static final int TICKS_FOR_SCHEDULED_WAKE = 5;
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+    private NamespacedKey markerKey;
+
+    private void load(boolean persist) {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(
+                getClass().getResourceAsStream("/config.yml"), StandardCharsets.UTF_8));
+        config.set("persist-lobotomized-state", persist);
+        plugin = MockBukkit.loadWithConfig(VillagerLobotomizer.class, config);
+        world = server.addSimpleWorld("test");
+        markerKey = new NamespacedKey(plugin, LobotomizeStorage.LOBOTOMIZED_KEY);
+    }
+
+    /** A lobotomized, marked villager, as a running server would have it. */
+    private Villager lobotomizedVillager() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        plugin.getStorage().removeVillager(villager);
+        villager.getPersistentDataContainer().set(markerKey, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        return villager;
+    }
+
+    private boolean hasMarker(Villager villager) {
+        return villager.getPersistentDataContainer().has(markerKey, PersistentDataType.BYTE);
+    }
+
+    @Test
+    void shutdownPreservesNoAiAndMarker() {
+        load(true);
+        Villager villager = lobotomizedVillager();
+        assertFalse(villager.isAware(), "precondition: the villager is lobotomized");
+
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.SHUTDOWN);
+
+        assertFalse(villager.isAware(), "a restart must not wake lobotomized villagers");
+        assertTrue(hasMarker(villager), "and the marker must survive so it is re-tracked on load");
+    }
+
+    @Test
+    void shutdownKeepsTheTrackingRow() throws SQLException {
+        load(true);
+        LobotomizedMarkerStore store = plugin.getMarkerStore();
+        lobotomizedVillager();
+
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.SHUTDOWN);
+        store.drainNow();
+
+        assertEquals(1, store.loadAll().size(), "the row must survive so uninstall can still find it");
+    }
+
+    @Test
+    void shutdownWakesAndClearsWhenPersistenceIsDisabled() {
+        load(false);
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        plugin.getStorage().removeVillager(villager);
+        villager.setAware(false);
+        villager.getPersistentDataContainer().set(markerKey, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.SHUTDOWN);
+
+        assertTrue(villager.isAware(), "with persistence off there is nothing to restore from, so wake");
+        assertFalse(hasMarker(villager), "and leave no marker behind");
+    }
+
+    @Test
+    void reloadStillWakesAndClears() {
+        load(true);
+        Villager villager = lobotomizedVillager();
+
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.RELOAD);
+        server.getScheduler().performTicks(TICKS_FOR_SCHEDULED_WAKE);
+
+        assertTrue(villager.isAware(), "a reload rescans immediately, so it must hand back a clean slate");
+        assertFalse(hasMarker(villager), "and clear the marker");
+    }
+
+    @Test
+    void reloadDropsTheTrackingRow() throws SQLException {
+        load(true);
+        LobotomizedMarkerStore store = plugin.getMarkerStore();
+        lobotomizedVillager();
+
+        plugin.getStorage().flush(LobotomizeStorage.FlushMode.RELOAD);
+        server.getScheduler().performTicks(TICKS_FOR_SCHEDULED_WAKE);
+        store.drainNow();
+
+        assertTrue(store.loadAll().isEmpty(), "clearing the marker on reload should drop the row too");
+    }
+
+    @Test
+    void quiesceForUninstallLeavesVillagersUntouched() {
+        load(true);
+        Villager villager = lobotomizedVillager();
+
+        // The sweep owns all entity work, so quiescing must not pre-empt it.
+        assertEquals(1, plugin.getStorage().quiesceForUninstall().size(), "the tracked villager is handed back");
+        assertFalse(villager.isAware(), "quiescing must not wake anything");
+        assertTrue(hasMarker(villager), "nor clear any marker");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageMarkerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/LobotomizeStorageMarkerTest.java
@@ -1,0 +1,82 @@
+package dev.mja00.villagerLobotomizer;
+
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
+import dev.mja00.villagerLobotomizer.storage.MarkedVillager;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The rule the uninstall sweep depends on: a row exists exactly when the plugin has written the PDC
+ * marker on that villager.
+ */
+class LobotomizeStorageMarkerTest extends MockBukkitTestBase {
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+    private NamespacedKey markerKey;
+    private LobotomizedMarkerStore store;
+
+    @BeforeEach
+    void loadPlugin() {
+        plugin = MockBukkit.load(VillagerLobotomizer.class);
+        world = server.addSimpleWorld("test");
+        markerKey = new NamespacedKey(plugin, LobotomizeStorage.LOBOTOMIZED_KEY);
+        store = plugin.getMarkerStore();
+    }
+
+    private Villager untrackedVillager() {
+        Villager villager = world.spawn(new Location(world, 24, 64, 40), Villager.class);
+        plugin.getStorage().removeVillager(villager);
+        return villager;
+    }
+
+    @Test
+    void honouringAnExistingMarkerRecordsARow() throws SQLException {
+        Villager villager = untrackedVillager();
+        villager.getPersistentDataContainer().set(markerKey, PersistentDataType.BYTE, (byte) 1);
+
+        // An upgraded install has markers on disk but no rows yet, so tracking one must record it.
+        plugin.getStorage().addVillager(villager);
+        store.drainNow();
+
+        assertEquals(List.of(new MarkedVillager(villager.getUniqueId(), world.getUID(), 1, 2)),
+                store.loadAll(), "the row should record where the villager was found");
+    }
+
+    @Test
+    void clearingTheMarkerDeletesTheRow() throws SQLException {
+        Villager villager = untrackedVillager();
+        villager.getPersistentDataContainer().set(markerKey, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        store.drainNow();
+        assertEquals(1, store.loadAll().size(), "precondition: the villager has a row");
+
+        // This is the path /lobotomy wake takes.
+        plugin.getStorage().clearLobotomizedMarker(villager);
+        store.drainNow();
+
+        assertTrue(store.loadAll().isEmpty(), "clearing the marker should drop the row");
+    }
+
+    @Test
+    void clearingAnUnmarkedVillagerQueuesNoWrite() {
+        Villager villager = untrackedVillager();
+
+        // Active villagers get their marker cleared on every check, so this must stay free.
+        plugin.getStorage().clearLobotomizedMarker(villager);
+
+        assertEquals(0, store.getKnownRowCount(), "an unmarked villager should never gain a row");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/ProcessVillagerRepairTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/ProcessVillagerRepairTest.java
@@ -1,0 +1,47 @@
+package dev.mja00.villagerLobotomizer;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Villager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A villager tracked as active but left without AI must be woken. Before this repair the wake only
+ * ran on an inactive-to-active transition, so a villager that loaded asleep without a valid marker
+ * stayed frozen forever and, with trade prevention on, became untradeable.
+ *
+ * <p>Only the {@code addVillager} half is covered here. The periodic-check half cannot be tested
+ * under MockBukkit: any path reaching the activity policy calls {@code Block#isPassable}, which
+ * {@code BlockMock} does not implement, and the resulting exception is reported as a skipped test
+ * rather than a failure. Verify that half on a real server.
+ */
+class ProcessVillagerRepairTest extends MockBukkitTestBase {
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+
+    @BeforeEach
+    void loadPlugin() {
+        plugin = MockBukkit.load(VillagerLobotomizer.class);
+        world = server.addSimpleWorld("test");
+    }
+
+    @Test
+    void addingSleepingVillagerWithoutMarkerWakesItImmediately() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        // Spawning may already have fired an add event through the registered listener.
+        plugin.getStorage().removeVillager(villager);
+        villager.setAware(false);
+
+        plugin.getStorage().addVillager(villager);
+
+        assertTrue(villager.isAware(),
+                "a villager loaded asleep with no marker should be woken as it is tracked");
+        assertTrue(plugin.getStorage().getActive().contains(villager),
+                "and it should be tracked as active");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/UninstallSweepTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/UninstallSweepTest.java
@@ -61,10 +61,18 @@ class UninstallSweepTest extends MockBukkitTestBase {
         return new UninstallSweep(plugin, store, null, loadedChunksOnly);
     }
 
+    /** Drives the state machine directly, without its scheduled pump. */
     private void pumpUntilFinished(UninstallSweep sweep) {
         for (int i = 0; i < MAX_PUMPS && !sweep.isFinished(); i++) {
             sweep.pumpForTesting();
         }
+        assertTrue(sweep.isFinished(), "sweep should reach a terminal state");
+    }
+
+    /** Drives a sweep through its own scheduled pump, as the server would. */
+    private void runSweep(UninstallSweep sweep) {
+        sweep.start();
+        server.getScheduler().performTicks(MAX_PUMPS);
         assertTrue(sweep.isFinished(), "sweep should reach a terminal state");
     }
 
@@ -76,8 +84,7 @@ class UninstallSweepTest extends MockBukkitTestBase {
         assertFalse(villager.isAware(), "precondition: the villager is lobotomized");
 
         UninstallSweep sweep = newSweep();
-        sweep.start();
-        server.getScheduler().performTicks(20);
+        runSweep(sweep);
 
         assertTrue(villager.isAware(), "the sweep should restore AI");
         assertFalse(villager.getPersistentDataContainer().has(markerKey), "and remove the marker");
@@ -161,8 +168,7 @@ class UninstallSweepTest extends MockBukkitTestBase {
         store.drainNow();
 
         UninstallSweep sweep = newSweep();
-        sweep.start();
-        server.getScheduler().performTicks(20);
+        runSweep(sweep);
 
         assertFalse(plugin.getDataFolder().toPath()
                         .resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME).toFile().exists(),

--- a/src/test/java/dev/mja00/villagerLobotomizer/UninstallSweepTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/UninstallSweepTest.java
@@ -1,0 +1,201 @@
+package dev.mja00.villagerLobotomizer;
+
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behaviour of the uninstall sweep. Chunk loading is injected because MockBukkit throws from
+ * {@code getChunkAtAsync}; the accessor here hands back already-loaded chunks and {@code null}
+ * otherwise, which is what an ungenerated chunk looks like to the sweep.
+ *
+ * <p>Tests that skip {@code start()} exercise the row-driven phase in isolation: {@code start()} is
+ * what restores villagers already in memory, and it would otherwise reach every villager in a mock
+ * world before the rows are ever read.
+ */
+class UninstallSweepTest extends MockBukkitTestBase {
+
+    private static final int MAX_PUMPS = 50;
+
+    private VillagerLobotomizer plugin;
+    private WorldMock world;
+    private NamespacedKey markerKey;
+    /** Held directly: a clean sweep clears the plugin's reference once it has deleted the file. */
+    private LobotomizedMarkerStore store;
+
+    private final UninstallSweep.ChunkAccessor loadedChunksOnly = (world, chunkX, chunkZ, callback) ->
+            callback.accept(world.isChunkLoaded(chunkX, chunkZ) ? world.getChunkAt(chunkX, chunkZ) : null);
+
+    @BeforeEach
+    void loadPlugin() {
+        plugin = MockBukkit.load(VillagerLobotomizer.class);
+        world = server.addSimpleWorld("test");
+        world.loadChunk(0, 0);
+        markerKey = new NamespacedKey(plugin, LobotomizeStorage.LOBOTOMIZED_KEY);
+        store = plugin.getMarkerStore();
+    }
+
+    /** A villager carrying the marker and tracked as lobotomized, as a restart would leave it. */
+    private Villager markedVillager() {
+        Villager villager = world.spawn(new Location(world, 8, 64, 8), Villager.class);
+        plugin.getStorage().removeVillager(villager);
+        villager.getPersistentDataContainer().set(markerKey, PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        return villager;
+    }
+
+    private UninstallSweep newSweep() {
+        return new UninstallSweep(plugin, store, null, loadedChunksOnly);
+    }
+
+    private void pumpUntilFinished(UninstallSweep sweep) {
+        for (int i = 0; i < MAX_PUMPS && !sweep.isFinished(); i++) {
+            sweep.pumpForTesting();
+        }
+        assertTrue(sweep.isFinished(), "sweep should reach a terminal state");
+    }
+
+    @Test
+    void restoresLoadedVillagerAndDropsItsRow() throws SQLException {
+        Villager villager = markedVillager();
+        store.drainNow();
+        assertEquals(1, store.loadAll().size(), "precondition: the villager has a row");
+        assertFalse(villager.isAware(), "precondition: the villager is lobotomized");
+
+        UninstallSweep sweep = newSweep();
+        sweep.start();
+        server.getScheduler().performTicks(20);
+
+        assertTrue(villager.isAware(), "the sweep should restore AI");
+        assertFalse(villager.getPersistentDataContainer().has(markerKey), "and remove the marker");
+        assertTrue(store.loadAll().isEmpty(), "and drop the row");
+        assertEquals(1, sweep.getRestoredCount());
+    }
+
+    @Test
+    void rowDrivenPhaseRestoresVillagerInItsRecordedChunk() throws SQLException {
+        Villager villager = markedVillager();
+        store.drainNow();
+
+        // No start(), so nothing has looked at loaded villagers: the row is the only way in.
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+
+        assertTrue(villager.isAware(), "the row-driven phase should restore AI");
+        assertFalse(villager.getPersistentDataContainer().has(markerKey), "and remove the marker");
+        assertTrue(store.loadAll().isEmpty(), "and drop the row");
+        assertEquals(1, sweep.getRestoredCount());
+    }
+
+    @Test
+    void rowForVillagerThatNoLongerExistsIsDroppedAndCounted() throws SQLException {
+        store.markerWritten(UUID.randomUUID(), world.getUID(), 0, 0);
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+
+        assertEquals(1, sweep.getUnresolvedCount(), "a row with no entity should be counted unresolved");
+        assertTrue(store.loadAll().isEmpty(), "and its row dropped, so it cannot be retried forever");
+    }
+
+    @Test
+    void rowInUnloadedWorldIsSkippedAndItsRowKept() throws SQLException {
+        store.markerWritten(UUID.randomUUID(), UUID.randomUUID(), 0, 0);
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+
+        assertEquals(1, sweep.getSkippedCount(), "a world that is not loaded should be skipped, not dropped");
+        assertEquals(1, store.loadAll().size(), "its row must survive so the command can finish later");
+        assertEquals(0, sweep.getUnresolvedCount());
+    }
+
+    @Test
+    void rowForUngeneratedChunkIsDroppedAndCounted() throws SQLException {
+        // Nothing has loaded this chunk, so the accessor reports it as absent.
+        store.markerWritten(UUID.randomUUID(), world.getUID(), 40, 40);
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+
+        assertEquals(1, sweep.getUnresolvedCount(), "an absent chunk means there is nothing to restore");
+        assertTrue(store.loadAll().isEmpty());
+    }
+
+    @Test
+    void staleChunkCoordinatesAreFoundInTheSecondPass() throws SQLException {
+        Villager villager = markedVillager();
+        store.drainNow();
+        // Pretend the villager was pushed across a chunk border since we last recorded it.
+        world.loadChunk(1, 0);
+        store.markerWritten(villager.getUniqueId(), world.getUID(), 1, 0);
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+
+        assertTrue(villager.isAware(), "the 3x3 second pass should still find it");
+        assertEquals(1, sweep.getRestoredCount());
+        assertEquals(0, sweep.getUnresolvedCount());
+    }
+
+    @Test
+    void cleanSweepDeletesTheStateFileAndDisablesThePlugin() {
+        markedVillager();
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        sweep.start();
+        server.getScheduler().performTicks(20);
+
+        assertFalse(plugin.getDataFolder().toPath()
+                        .resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME).toFile().exists(),
+                "a clean sweep should delete the state file");
+        assertFalse(plugin.isEnabled(), "and disable the plugin");
+    }
+
+    @Test
+    void incompleteSweepKeepsTheStateFileAndLeavesThePluginEnabled() {
+        store.markerWritten(UUID.randomUUID(), UUID.randomUUID(), 0, 0);
+        store.drainNow();
+
+        UninstallSweep sweep = newSweep();
+        pumpUntilFinished(sweep);
+        server.getScheduler().performTicks(5);
+
+        assertTrue(plugin.getDataFolder().toPath()
+                        .resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME).toFile().exists(),
+                "an incomplete sweep must keep the only record of what is left");
+        assertTrue(plugin.isEnabled(), "and stay enabled so the command can be re-run");
+    }
+
+    @Test
+    void secondUninstallIsRefusedWhileOneIsRunning() {
+        assertTrue(plugin.startUninstall(server.getConsoleSender()), "the first uninstall should start");
+        assertFalse(plugin.startUninstall(server.getConsoleSender()), "a concurrent uninstall should be refused");
+    }
+
+    @Test
+    void reloadIsRefusedWhileUninstalling() {
+        assertTrue(plugin.startUninstall(server.getConsoleSender()));
+
+        assertEquals(-1, plugin.reloadPluginState(),
+                "a reload would re-lobotomize villagers the sweep is clearing");
+    }
+}

--- a/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/listeners/EntityListenerTest.java
@@ -2,15 +2,21 @@ package dev.mja00.villagerLobotomizer.listeners;
 
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import dev.mja00.villagerLobotomizer.LobotomizeStorage;
 import dev.mja00.villagerLobotomizer.MockBukkitTestBase;
 import dev.mja00.villagerLobotomizer.VillagerLobotomizer;
+import dev.mja00.villagerLobotomizer.storage.LobotomizedMarkerStore;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.entity.EntityRemoveEvent;
+import org.bukkit.persistence.PersistentDataType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.world.WorldMock;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,6 +59,56 @@ class EntityListenerTest extends MockBukkitTestBase {
         server.getPluginManager().callEvent(new EntityRemoveFromWorldEvent(villager, world));
 
         assertFalse(isTracked(villager), "a removed villager should no longer be tracked");
+    }
+
+    /** A villager whose marker is on disk and whose row the store has already written. */
+    private Villager markedVillager() {
+        Villager villager = world.spawn(new Location(world, 0, 64, 0), Villager.class);
+        plugin.getStorage().removeVillager(villager);
+        villager.getPersistentDataContainer()
+                .set(new NamespacedKey(plugin, LobotomizeStorage.LOBOTOMIZED_KEY), PersistentDataType.BYTE, (byte) 1);
+        plugin.getStorage().addVillager(villager);
+        store().drainNow();
+        return villager;
+    }
+
+    private LobotomizedMarkerStore store() {
+        return plugin.getMarkerStore();
+    }
+
+    private int rowCount() throws Exception {
+        store().drainNow();
+        return store().loadAll().size();
+    }
+
+    @Test
+    void deathDropsTheTrackingRow() throws Exception {
+        Villager villager = markedVillager();
+        assertEquals(1, rowCount(), "precondition: the villager has a row");
+
+        server.getPluginManager().callEvent(new EntityRemoveEvent(villager, EntityRemoveEvent.Cause.DEATH));
+
+        assertEquals(0, rowCount(), "a dead villager's row should be dropped");
+    }
+
+    @Test
+    void chunkUnloadKeepsTheTrackingRow() throws Exception {
+        Villager villager = markedVillager();
+
+        server.getPluginManager().callEvent(new EntityRemoveEvent(villager, EntityRemoveEvent.Cause.UNLOAD));
+
+        assertEquals(1, rowCount(),
+                "an unloaded villager keeps its marker on disk, so its row must survive too");
+    }
+
+    @Test
+    void transformationDropsTheTrackingRow() throws Exception {
+        Villager villager = markedVillager();
+
+        // Villager to zombie villager: the entity is replaced, so the marker goes with it.
+        server.getPluginManager().callEvent(new EntityRemoveEvent(villager, EntityRemoveEvent.Cause.TRANSFORMATION));
+
+        assertEquals(0, rowCount(), "a converted villager's row should be dropped");
     }
 
     @Test

--- a/src/test/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStoreTest.java
+++ b/src/test/java/dev/mja00/villagerLobotomizer/storage/LobotomizedMarkerStoreTest.java
@@ -1,0 +1,204 @@
+package dev.mja00.villagerLobotomizer.storage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Persistence and buffering behaviour of {@link LobotomizedMarkerStore}. No MockBukkit needed: the
+ * store only touches Bukkit for its scheduled drain and the {@code Villager} overload.
+ */
+class LobotomizedMarkerStoreTest {
+
+    private static final Logger LOGGER = Logger.getLogger(LobotomizedMarkerStoreTest.class.getName());
+
+    @TempDir
+    Path dataFolder;
+
+    private LobotomizedMarkerStore openStore() {
+        LobotomizedMarkerStore store = new LobotomizedMarkerStore(
+                dataFolder.resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME), LOGGER);
+        assertTrue(store.open(), "store should open in a temp folder");
+        return store;
+    }
+
+    @Test
+    void roundTripsRowAcrossReopen() throws SQLException {
+        UUID entity = UUID.randomUUID();
+        UUID world = UUID.randomUUID();
+
+        LobotomizedMarkerStore store = openStore();
+        store.markerWritten(entity, world, 3, -7);
+        store.drainNow();
+        store.close();
+
+        LobotomizedMarkerStore reopened = openStore();
+        try {
+            assertEquals(List.of(new MarkedVillager(entity, world, 3, -7)), reopened.loadAll(),
+                    "a drained row should survive a reopen");
+            assertEquals(1, reopened.getKnownRowCount());
+        } finally {
+            reopened.close();
+        }
+    }
+
+    @Test
+    void clearRemovesRow() throws SQLException {
+        UUID entity = UUID.randomUUID();
+        LobotomizedMarkerStore store = openStore();
+        try {
+            store.markerWritten(entity, UUID.randomUUID(), 0, 0);
+            store.drainNow();
+            assertEquals(1, store.loadAll().size(), "precondition: row was written");
+
+            store.markerCleared(entity);
+            store.drainNow();
+
+            assertTrue(store.loadAll().isEmpty(), "clearing the marker should delete the row");
+            assertEquals(0, store.getKnownRowCount());
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void lastIntentWinsWhenCoalesced() throws SQLException {
+        UUID entity = UUID.randomUUID();
+        UUID world = UUID.randomUUID();
+        LobotomizedMarkerStore store = openStore();
+        try {
+            store.markerWritten(entity, world, 1, 1);
+            store.markerCleared(entity);
+            store.markerWritten(entity, world, 9, 9);
+            store.drainNow();
+
+            assertEquals(List.of(new MarkedVillager(entity, world, 9, 9)), store.loadAll(),
+                    "the newest intent should be the one written");
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void repeatedFlipsDoNotGrowPendingBuffer() {
+        UUID entity = UUID.randomUUID();
+        UUID world = UUID.randomUUID();
+        LobotomizedMarkerStore store = openStore();
+        try {
+            for (int i = 0; i < 1000; i++) {
+                store.markerWritten(entity, world, i, i);
+                store.markerCleared(entity);
+            }
+
+            assertEquals(1, store.pendingCount(), "coalescing by entity should keep the buffer at one entry");
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void skipsRedundantWriteForUnchangedChunk() {
+        UUID entity = UUID.randomUUID();
+        UUID world = UUID.randomUUID();
+        LobotomizedMarkerStore store = openStore();
+        try {
+            store.markerWritten(entity, world, 4, 4);
+            store.drainNow();
+            assertEquals(0, store.pendingCount(), "precondition: nothing pending after a drain");
+
+            store.markerWritten(entity, world, 4, 4);
+            assertEquals(0, store.pendingCount(), "re-writing the same chunk should enqueue nothing");
+
+            store.markerWritten(entity, world, 5, 4);
+            assertEquals(1, store.pendingCount(), "a moved villager should enqueue an update");
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void clearForUnknownVillagerEnqueuesNothing() {
+        LobotomizedMarkerStore store = openStore();
+        try {
+            // Active villagers have their marker cleared on every check, so this must stay free.
+            for (int i = 0; i < 100; i++) {
+                store.markerCleared(UUID.randomUUID());
+            }
+
+            assertEquals(0, store.pendingCount(), "clearing a villager we hold no row for should be a no-op");
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void clearForKnownRowEnqueuesDelete() {
+        UUID entity = UUID.randomUUID();
+        LobotomizedMarkerStore store = openStore();
+        try {
+            store.markerWritten(entity, UUID.randomUUID(), 0, 0);
+            store.drainNow();
+
+            // The row can outlive its marker if the chunk never saved, so this must still fire.
+            store.markerCleared(entity);
+
+            assertEquals(1, store.pendingCount(), "clearing a known row should enqueue a delete");
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    void openFailureLeavesStoreUnusableWithoutThrowing() throws Exception {
+        Path blocker = dataFolder.resolve("blocker");
+        Files.writeString(blocker, "not a directory");
+
+        LobotomizedMarkerStore store = new LobotomizedMarkerStore(blocker.resolve("nested/state.db"), LOGGER);
+
+        assertFalse(store.open(), "opening under a regular file should fail");
+        assertFalse(store.isUsable());
+        store.markerWritten(UUID.randomUUID(), UUID.randomUUID(), 0, 0);
+        store.markerCleared(UUID.randomUUID());
+        store.drainNow();
+        assertEquals(0, store.pendingCount(), "an unusable store should ignore writes rather than buffer them");
+        store.close();
+    }
+
+    @Test
+    void deleteDatabaseFilesRemovesSidecars() {
+        LobotomizedMarkerStore store = openStore();
+        store.markerWritten(UUID.randomUUID(), UUID.randomUUID(), 0, 0);
+        store.drainNow();
+
+        assertTrue(store.deleteDatabaseFiles(), "delete should report success");
+
+        Path database = dataFolder.resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME);
+        assertFalse(Files.exists(database), "the database file should be gone");
+        assertFalse(Files.exists(dataFolder.resolve(database.getFileName() + "-wal")), "the WAL should be gone");
+        assertFalse(Files.exists(dataFolder.resolve(database.getFileName() + "-shm")), "the shm should be gone");
+    }
+
+    @Test
+    void drainAfterDeleteDoesNotRecreateTheDatabase() {
+        LobotomizedMarkerStore store = openStore();
+        store.markerWritten(UUID.randomUUID(), UUID.randomUUID(), 0, 0);
+        store.deleteDatabaseFiles();
+
+        // onDisable still runs after the uninstall sweep deleted the file.
+        store.drainNow();
+        store.close();
+
+        assertFalse(Files.exists(dataFolder.resolve(LobotomizedMarkerStore.DATABASE_FILE_NAME)),
+                "a drain after deletion must not resurrect the state file");
+    }
+}

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -65,7 +65,7 @@ prevent-trading-with-unlobotomized-villagers: false
 #Message that is sent to players when they try to trade with an unlobotomized villager. Supports MiniMessage.
 unlobotomized-villager-trade-message: "<red>You cannot trade with unlobotomized villagers!</red> <yellow>This villager needs to be lobotomized first.</yellow>"
 
-#Persist lobotomized state across chunk unloads.
+#Persist lobotomized state across chunk unloads and restarts.
 persist-lobotomized-state: true
 
 #Sentry disabled for tests to avoid network init during MockBukkit.load().


### PR DESCRIPTION
## Problem

A user reported that after their nightly reboot no villagers are lobotomized, so the lag spike returns every morning until `check-interval` elapses.

`flush()` wiped everything on shutdown: it woke every tracked villager and stripped the `isLobotomized` PDC marker. Paper disables plugins *before* saving worlds, so that wiped state is exactly what got serialized. `persist-lobotomized-state` only ever survived chunk unload/load, never a restart.

The wipe existed to make uninstalling painless, and it did that badly anyway: it could only reach villagers in loaded chunks, so markers elsewhere were left behind regardless.

## What changed

Three stages, one commit each, ordered so an escape hatch always exists before the behaviour change lands.

**1. `fix: wake villagers tracked active but left without ai`**

A latent bug already on `main`. `processVillager`'s active branch had `setAware(true)` inside `if (!active)`, so a villager tracked active but actually asleep was never woken, not on that check and not ever. The shutdown wipe hid it. Persisting state would have turned it into permanently frozen villagers that, with `prevent-trading-with-unlobotomized-villagers` on, players could not trade with. This had to land first.

**2. `feat: track lobotomized villagers in sqlite and add /lobotomy uninstall`**

New `storage/LobotomizedMarkerStore` backed by `state.db`, holding one row per marked villager (entity, world, chunk). Invariant: **a row exists exactly when the plugin has written the marker**. Every marker mutation now goes through `setLobotomizedMarker` / `clearLobotomizedMarker`, which keep the row in sync.

- Writes never touch JDBC on an entity thread. They update a single intent map via `compute()`, drained on an async task every 5s. Suppression in both directions keeps steady-state writes near zero, which matters because active villagers have their marker cleared on *every* check tick.
- Row deletion is driven by `EntityRemoveEvent` with a non-`UNLOAD` cause, not by `isDead()`/`isValid()`. Those two are also false for a merely unloaded entity, so keying off them would drop the row while the marker sat on disk, orphaning exactly the villager the sweep exists to find.
- `/lobotomy uninstall` explains and does nothing; `/lobotomy uninstall confirm` runs the sweep: quiesce, restore everything in memory via each entity's scheduler, then walk the remaining rows chunk by chunk (`getChunkAtAsync` with `generate=false`, 8 loads in flight, `isOwnedByCurrentRegion` guard then a `RegionScheduler` hop), plus a 3x3 second pass for villagers pushed across a chunk border.
- It only deletes rows it actually cleared. If anything is skipped or unresolved it keeps `state.db` and stays enabled so the command can be re-run, rather than deleting the only record of what is left while claiming success.
- New `lobotomy.command.uninstall` permission in both descriptors.

**3. `feat: keep villagers lobotomized across server restarts`**

`flush(FlushMode.SHUTDOWN)` preserves state and markers when persistence is on. `RELOAD` still wakes and clears, because the replacement storage rescans immediately. `flush(boolean)` stays as a deprecated delegate since it is public API. Config comment, README and `CLAUDE.md` updated, plus a one-time startup line, because the config comment cannot reach existing installs (the migrator prefers the user's own comment).

## Two things to look at

**I reversed a decision from the plan.** It called for relocating `org.sqlite` and said explicitly not to un-relocate. That is wrong. The bundled native library has the JNI class name `org/sqlite/core/NativeDB` compiled into it, so a renamed package cannot link: I got `NoClassDefFoundError: org/sqlite/core/NativeDB` thrown from `NativeLibraries.load`, a native method. It is now shaded unrelocated, with the usual `DriverManager` hazard removed by opening connections through `SQLiteDataSource` and shipping no `META-INF/services/java.sql.Driver`. Reasoning is in `build.gradle.kts` and `CLAUDE.md`.

**Jar size goes from about 1M to 6.1M.** sqlite-jdbc bundles 19 native libraries and `minimize` has to be off for it. I trimmed to the 8 platforms a Paper server realistically runs on, which took it from 13M to 6.1M. Dropping the musl builds and Windows/aarch64 would save roughly 3M more if that is still too big.

## Verification

`./gradlew clean test build`: **79 tests, 0 failures, 0 skipped** (46 before, 33 new). Both regression tests were confirmed to fail with their production fix reverted.

Also five runs against a real Paper server with the shaded jar, since the load-bearing parts cannot be unit-tested:

| Check | Result |
| --- | --- |
| Trap a villager in a sealed box | Lobotomized after one check; `state.db` row records chunk (6,6), which is correct for block 101 |
| Restart with `check-interval: 12000` | Still lobotomized immediately. With a 10 minute interval that can only come from persisted state, so this is the reported bug fixed |
| `uninstall confirm` with the chunk unloaded | `Loading 1 chunk(s) to reach villagers that are not in memory` then `Restored 1 villager(s)`; file deleted; plugin self-disabled |
| Reboot after uninstall | `Lobotomized: 0`, still on a 10 minute interval, so the marker was genuinely cleared |

Enabling the plugin on a real server also confirms the unrelocated driver loads inside Paper's plugin classloader, which the standalone check could not prove.

## Known limitations

- **Existing installs have markers but no rows.** Rows only appear as chunks load and `addVillager` self-heals, so villagers in chunks that never load between upgrading and uninstalling are invisible to the sweep. Not a regression, since today's shutdown wipe cannot reach them either, but worth saying in release notes. Anyone wanting a guaranteed clean removal should uninstall on the current jar first.
- **Folia is unverified.** `runServer` is pinned to Paper and there is no Folia run task. `getChunkAtAsync`'s completion thread is undocumented there; the `isOwnedByCurrentRegion` guard makes the code correct either way, but it has not been exercised on Folia.
- **Deleting the jar without running the command** now leaves every villager the plugin ever slept without AI. That is the cost of persisting state, and the reason for the startup notice and the README section.
- The periodic-check half of stage 1 has no unit test: anything reaching the activity policy calls `Block#isPassable`, which MockBukkit does not implement, and it surfaces as a *skipped* test rather than a failure. Documented in `CLAUDE.md` along with the other MockBukkit traps, and verified manually instead.
